### PR TITLE
UniversalDaoのDB接続時にDialectを使用するための機能を追加

### DIFF
--- a/src/main/java/nablarch/core/db/cache/ColumnDescriptor.java
+++ b/src/main/java/nablarch/core/db/cache/ColumnDescriptor.java
@@ -1,0 +1,44 @@
+package nablarch.core.db.cache;
+
+/**
+ * データベースのカラムに関するメタ情報を保持するクラス。
+ * @author ryo asato
+ */
+public class ColumnDescriptor {
+
+    private String columnName;
+
+    private int columnType;
+
+    private Class columnClass;
+
+    public ColumnDescriptor(String columnName, int columnType, Class columnClass) {
+        this.columnName = columnName;
+        this.columnType = columnType;
+        this.columnClass = columnClass;
+    }
+
+    /**
+     * カラム名を取得する。
+     * @return カラム名
+     */
+    public String getColumnName() {
+        return columnName;
+    }
+
+    /**
+     * SQL型を取得する。
+     * @return {@link java.sql.Types}からのSQL型
+     */
+    public int getColumnType() {
+        return columnType;
+    }
+
+    /**
+     * 対応するJavaのクラスを返す。
+     * @return {@link Class}
+     */
+    public Class getColumnClass() {
+        return columnClass;
+    }
+}

--- a/src/main/java/nablarch/core/db/cache/ColumnDescriptor.java
+++ b/src/main/java/nablarch/core/db/cache/ColumnDescriptor.java
@@ -10,12 +10,9 @@ public class ColumnDescriptor {
 
     private int columnType;
 
-    private Class columnClass;
-
-    public ColumnDescriptor(String columnName, int columnType, Class columnClass) {
+    public ColumnDescriptor(String columnName, int columnType) {
         this.columnName = columnName;
         this.columnType = columnType;
-        this.columnClass = columnClass;
     }
 
     /**
@@ -34,11 +31,4 @@ public class ColumnDescriptor {
         return columnType;
     }
 
-    /**
-     * 対応するJavaのクラスを返す。
-     * @return {@link Class}
-     */
-    public Class getColumnClass() {
-        return columnClass;
-    }
 }

--- a/src/main/java/nablarch/core/db/cache/DataBaseMetaDataCache.java
+++ b/src/main/java/nablarch/core/db/cache/DataBaseMetaDataCache.java
@@ -1,0 +1,116 @@
+package nablarch.core.db.cache;
+
+import nablarch.core.db.DbAccessException;
+import nablarch.core.util.StringUtil;
+
+import java.sql.*;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * データベースのメタデータをキャッシュするクラス。
+ * @author ryo asato
+ */
+public class DataBaseMetaDataCache {
+
+    private static DataBaseMetaDataCache instance = null;
+    private Map<String, TableDescriptor> tableDescriptorMap = new HashMap<String, TableDescriptor>();
+
+    private DataBaseMetaDataCache() {
+    }
+
+    public static synchronized DataBaseMetaDataCache getInstance() {
+        if (instance == null) {
+            instance = new DataBaseMetaDataCache();
+        }
+        return instance;
+    }
+
+    /**
+     * 指定したテーブルに対応する{@link TableDescriptor}を取得する。
+     * スキーマ名を指定しなかった場合、デフォルトスキーマを参照する。
+     *
+     * @param schema スキーマ名
+     * @param tableName テーブル名
+     * @param connection {@link Connection}
+     * @return {@link TableDescriptor}
+     */
+    public TableDescriptor getTableDescriptor(String schema, String tableName, Connection connection) {
+        if (StringUtil.isNullOrEmpty(tableName) || connection == null) {
+            throw new IllegalArgumentException("tableName or connection is null or empty.");
+        }
+
+        String key = addSchema(schema, tableName);
+        TableDescriptor tableDescriptor = tableDescriptorMap.get(key);
+        if (tableDescriptor == null) {
+            synchronized (this) {
+                ResultSetMetaData metaData = getMetaData(schema, tableName, connection);
+                tableDescriptor = new TableDescriptor(tableName, createColumnDescriptors(tableName, metaData));
+                tableDescriptorMap.put(key, tableDescriptor);
+            }
+        }
+        return tableDescriptor;
+    }
+
+    /**
+     * 指定したテーブルのカラムに対応する{@link ColumnDescriptor}を取得する。
+     * スキーマ名を指定しなかった場合、デフォルトスキーマを参照する。
+     *
+     * @param schema スキーマ名
+     * @param tableName テーブル名
+     * @param columnName カラム名
+     * @param connection {@link Connection}
+     * @return {@link ColumnDescriptor}
+     */
+    public ColumnDescriptor getColumnDescriptor(String schema, String tableName, String columnName, Connection connection) {
+        if (StringUtil.isNullOrEmpty(tableName) || StringUtil.isNullOrEmpty(columnName) || connection == null) {
+            throw new IllegalArgumentException("tableName, columnName or connection is null or empty.");
+        }
+
+        TableDescriptor tableDescriptor = getTableDescriptor(schema, tableName, connection);
+        return tableDescriptor.getColumnDescriptor(columnName);
+    }
+
+    private Map<String, ColumnDescriptor> createColumnDescriptors(String tableName, ResultSetMetaData meta) {
+        Map<String, ColumnDescriptor> ret = new HashMap<String, ColumnDescriptor>();
+        String className = null;
+        try {
+            for (int i = 1; i <= meta.getColumnCount(); i++) {
+                String columnName = meta.getColumnName(i);
+                int columnType = meta.getColumnType(i);
+                className = meta.getColumnClassName(i);
+                ret.put(columnName, new ColumnDescriptor(columnName, columnType, Class.forName(className)));
+            }
+        } catch (SQLException e) {
+            throw new DbAccessException("Can not access to metadata. tablename = " + tableName, e);
+        } catch (ClassNotFoundException e) {
+            // データベースのメタ情報から取得したクラス名を指定しているので、ここには到達しない
+            throw new IllegalStateException("Can not create Class object. class = " + className, e);
+        }
+        return ret;
+    }
+
+    /**
+     * 指定したテーブルのメタ情報をデータベースから取得する。
+     * スキーマ名を指定しなかった場合、デフォルトスキーマを参照する。
+     *
+     * @param schema スキーマ名
+     * @param tableName テーブル名
+     * @param connection {@link Connection}
+     * @return {@link ResultSetMetaData}
+     */
+    private ResultSetMetaData getMetaData(String schema, String tableName, Connection connection) {
+        // メタデータ取得用のSQL
+        String sql = "SELECT * FROM " + addSchema(schema, tableName) + " WHERE 1 = 0";
+        try {
+            PreparedStatement ps = connection.prepareStatement(sql);
+            return ps.executeQuery().getMetaData();
+        } catch (SQLException e) {
+            throw new DbAccessException("Can not access to metadata. tablename = " + tableName, e);
+        }
+    }
+
+    private String addSchema(String schema, String tableName) {
+        return StringUtil.hasValue(schema) ? schema + "." + tableName : tableName;
+    }
+}

--- a/src/main/java/nablarch/core/db/cache/DataBaseMetaDataCache.java
+++ b/src/main/java/nablarch/core/db/cache/DataBaseMetaDataCache.java
@@ -73,19 +73,14 @@ public class DataBaseMetaDataCache {
 
     private Map<String, ColumnDescriptor> createColumnDescriptors(String tableName, ResultSetMetaData meta) {
         Map<String, ColumnDescriptor> ret = new HashMap<String, ColumnDescriptor>();
-        String className = null;
         try {
             for (int i = 1; i <= meta.getColumnCount(); i++) {
                 String columnName = meta.getColumnName(i);
                 int columnType = meta.getColumnType(i);
-                className = meta.getColumnClassName(i);
-                ret.put(columnName, new ColumnDescriptor(columnName, columnType, Class.forName(className)));
+                ret.put(columnName, new ColumnDescriptor(columnName, columnType));
             }
         } catch (SQLException e) {
             throw new DbAccessException("Can not access to metadata. tablename = " + tableName, e);
-        } catch (ClassNotFoundException e) {
-            // データベースのメタ情報から取得したクラス名を指定しているので、ここには到達しない
-            throw new IllegalStateException("Can not create Class object. class = " + className, e);
         }
         return ret;
     }

--- a/src/main/java/nablarch/core/db/cache/TableDescriptor.java
+++ b/src/main/java/nablarch/core/db/cache/TableDescriptor.java
@@ -1,0 +1,38 @@
+package nablarch.core.db.cache;
+
+import java.util.Map;
+
+/**
+ * データベースのテーブルに関するメタ情報を保持するクラス。
+ * @author ryo asato
+ */
+public class TableDescriptor {
+
+    private String tableName;
+
+    private Map<String, ColumnDescriptor> columnDescMap;
+
+    public TableDescriptor(String tableName, Map<String, ColumnDescriptor> columnDescMap) {
+        this.tableName = tableName;
+        this.columnDescMap = columnDescMap;
+    }
+
+    /**
+     * 指定したカラムの{@link ColumnDescriptor}を取得する。
+     * 指定したカラムが存在しない場合、nullを返す。
+     * @param columnName カラム名
+     * @return {@link ColumnDescriptor}
+     */
+    public ColumnDescriptor getColumnDescriptor(String columnName) {
+        return columnDescMap.get(columnName);
+    }
+
+    /**
+     * テーブル名を返す。
+     * @return テーブル名
+     */
+    public String getTableName() {
+        return tableName;
+    }
+}
+

--- a/src/main/java/nablarch/core/db/cache/TableDescriptor.java
+++ b/src/main/java/nablarch/core/db/cache/TableDescriptor.java
@@ -10,21 +10,29 @@ public class TableDescriptor {
 
     private String tableName;
 
+    private boolean isCaseSensitive;
+
     private Map<String, ColumnDescriptor> columnDescMap;
 
-    public TableDescriptor(String tableName, Map<String, ColumnDescriptor> columnDescMap) {
+    public TableDescriptor(String tableName, boolean isCaseSensitive, Map<String, ColumnDescriptor> columnDescMap) {
         this.tableName = tableName;
+        this.isCaseSensitive = isCaseSensitive;
         this.columnDescMap = columnDescMap;
     }
 
     /**
      * 指定したカラムの{@link ColumnDescriptor}を取得する。
-     * 指定したカラムが存在しない場合、nullを返す。
+     * 指定したカラムが存在しない場合、{@link IllegalArgumentException}を返す。
      * @param columnName カラム名
      * @return {@link ColumnDescriptor}
      */
     public ColumnDescriptor getColumnDescriptor(String columnName) {
-        return columnDescMap.get(columnName);
+        String key = isCaseSensitive ? columnName : columnName.toUpperCase();
+        ColumnDescriptor columnDescriptor = columnDescMap.get(key);
+        if (columnDescriptor == null) {
+            throw new IllegalArgumentException("column not found. column: " + columnName);
+        }
+        return columnDescriptor;
     }
 
     /**
@@ -35,4 +43,3 @@ public class TableDescriptor {
         return tableName;
     }
 }
-

--- a/src/main/java/nablarch/core/db/dialect/DefaultSqlTypeConverter.java
+++ b/src/main/java/nablarch/core/db/dialect/DefaultSqlTypeConverter.java
@@ -1,0 +1,35 @@
+package nablarch.core.db.dialect;
+
+import java.sql.Types;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * {@link SqlTypeConverter}のデフォルト実装
+ * @author ryo asato
+ */
+public class DefaultSqlTypeConverter implements SqlTypeConverter {
+
+    /**
+     * SQL型に対応するJavaクラスのマッピング定義。
+     */
+    private static final Map<Integer, Class> CLASS_CONVERTER_MAP;
+
+    static {
+        final Map<Integer, Class> classConverterMap = new HashMap<Integer, Class>();
+        // TODO マッピング
+        classConverterMap.put(Types.CHAR, String.class);
+
+        CLASS_CONVERTER_MAP = Collections.unmodifiableMap(classConverterMap);
+    }
+
+    @Override
+    public Class convertToJavaClass(int sqlType) {
+        Class converted = CLASS_CONVERTER_MAP.get(sqlType);
+        if (converted == null) {
+            throw new IllegalArgumentException("unsupported sqlType: " + sqlType);
+        }
+        return converted;
+    }
+}

--- a/src/main/java/nablarch/core/db/dialect/DefaultSqlTypeConverter.java
+++ b/src/main/java/nablarch/core/db/dialect/DefaultSqlTypeConverter.java
@@ -1,12 +1,17 @@
 package nablarch.core.db.dialect;
 
-import java.sql.Types;
+import java.math.BigDecimal;
+import java.net.URL;
+import java.sql.*;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
 /**
  * {@link SqlTypeConverter}のデフォルト実装
+ * jdbc3.0で定義されているSQL型のうち、対応する型が明確なものを対象としている。
+ * 変換後の型は{@link PreparedStatement}のsetXXで変換されるSQL型との対応に準じている。
+ *
  * @author ryo asato
  */
 public class DefaultSqlTypeConverter implements SqlTypeConverter {
@@ -18,8 +23,32 @@ public class DefaultSqlTypeConverter implements SqlTypeConverter {
 
     static {
         final Map<Integer, Class> classConverterMap = new HashMap<Integer, Class>();
-        // TODO マッピング
+        classConverterMap.put(Types.BIT, Boolean.class);
+        classConverterMap.put(Types.TINYINT, Byte.class);
+        classConverterMap.put(Types.SMALLINT, Short.class);
+        classConverterMap.put(Types.INTEGER, Integer.class);
+        classConverterMap.put(Types.BIGINT, Long.class);
+        classConverterMap.put(Types.FLOAT, Double.class);
+        classConverterMap.put(Types.REAL, Float.class);
+        classConverterMap.put(Types.DOUBLE, Double.class);
+        classConverterMap.put(Types.NUMERIC, BigDecimal.class);
+        classConverterMap.put(Types.DECIMAL, BigDecimal.class);
         classConverterMap.put(Types.CHAR, String.class);
+        classConverterMap.put(Types.VARCHAR, String.class);
+        classConverterMap.put(Types.LONGVARCHAR, String.class);
+        classConverterMap.put(Types.DATE, java.sql.Date.class);
+        classConverterMap.put(Types.TIME, java.sql.Time.class);
+        classConverterMap.put(Types.TIMESTAMP, java.sql.Timestamp.class);
+        classConverterMap.put(Types.BINARY, byte[].class);
+        classConverterMap.put(Types.VARBINARY, byte[].class);
+        classConverterMap.put(Types.LONGVARBINARY, byte[].class);
+        classConverterMap.put(Types.STRUCT, Struct.class);
+        classConverterMap.put(Types.ARRAY, Array.class);
+        classConverterMap.put(Types.BLOB, Blob.class);
+        classConverterMap.put(Types.CLOB, Clob.class);
+        classConverterMap.put(Types.REF, Ref.class);
+        classConverterMap.put(Types.DATALINK, URL.class);
+        classConverterMap.put(Types.BOOLEAN, Boolean.class);
 
         CLASS_CONVERTER_MAP = Collections.unmodifiableMap(classConverterMap);
     }

--- a/src/main/java/nablarch/core/db/dialect/SqlTypeConverter.java
+++ b/src/main/java/nablarch/core/db/dialect/SqlTypeConverter.java
@@ -1,0 +1,17 @@
+package nablarch.core.db.dialect;
+
+import java.sql.Types;
+
+/**
+ * {@link java.sql.Types}とJavaクラスのマッピングを管理するインタフェース。
+ * @author ryo asato
+ */
+public interface SqlTypeConverter {
+
+    /**
+     * SQL型に対応するJavaクラスを取得する。
+     * @param sqlType {@link Types}
+     * @return Javaのクラス
+     */
+    Class convertToJavaClass(int sqlType);
+}

--- a/src/test/java/nablarch/core/db/cache/DataBaseMetaDataCacheTest.java
+++ b/src/test/java/nablarch/core/db/cache/DataBaseMetaDataCacheTest.java
@@ -63,12 +63,10 @@ public class DataBaseMetaDataCacheTest {
         ColumnDescriptor colDescriptor = tableDescriptor.getColumnDescriptor("VARCHAR_COL");
         assertThat("列名の検証", colDescriptor.getColumnName(), is("VARCHAR_COL"));
         assertThat("SQL型の検証", colDescriptor.getColumnType(), is(Types.VARCHAR));
-        assertThat("クラス名の検証", colDescriptor.getColumnClass().getName(), is(String.class.getName()));
 
         colDescriptor = tableDescriptor.getColumnDescriptor("INT_COL");
         assertThat("列名の検証", colDescriptor.getColumnName(), is("INT_COL"));
         assertThat("SQL型の検証", colDescriptor.getColumnType(), is(Types.NUMERIC));
-        assertThat("クラス名の検証", colDescriptor.getColumnClass().getName(), is(BigDecimal.class.getName()));
 
         ColumnDescriptor checkColumnFromSsd = tableDescriptor.getColumnDescriptor("CHECK_COL");
 
@@ -78,20 +76,17 @@ public class DataBaseMetaDataCacheTest {
         colDescriptor = tableDescriptor.getColumnDescriptor("VARCHAR_COL");
         assertThat("列名の検証", colDescriptor.getColumnName(), is("VARCHAR_COL"));
         assertThat("SQL型の検証", colDescriptor.getColumnType(), is(Types.VARCHAR));
-        assertThat("クラス名の検証", colDescriptor.getColumnClass().getName(), is(String.class.getName()));
 
         // 指定したスキーマを参照できるか
         // ssdスキーマ
         assertThat("列名の検証", checkColumnFromSsd.getColumnName(), is("CHECK_COL"));
         assertThat("SQL型の検証", checkColumnFromSsd.getColumnType(), is(Types.VARCHAR));
-        assertThat("クラス名の検証", checkColumnFromSsd.getColumnClass().getName(), is(String.class.getName()));
         // nablarchスキーマ
         tableDescriptor = sut.getTableDescriptor("nablarch","RS_TEST", nativeConnection);
         assertThat("テーブル名の検証", tableDescriptor.getTableName(), is("RS_TEST"));
         colDescriptor = tableDescriptor.getColumnDescriptor("CHECK_COL");
         assertThat("列名の検証", colDescriptor.getColumnName(), is("CHECK_COL"));
         assertThat("SQL型の検証", colDescriptor.getColumnType(), is(Types.NUMERIC));
-        assertThat("クラス名の検証", colDescriptor.getColumnClass().getName(), is(BigDecimal.class.getName()));
     }
 
     @Test
@@ -100,13 +95,11 @@ public class DataBaseMetaDataCacheTest {
         ColumnDescriptor columnDescriptor = sut.getColumnDescriptor("ssd", "RS_TEST", "CHECK_COL", nativeConnection);
         assertThat("列名の検証", columnDescriptor.getColumnName(), is("CHECK_COL"));
         assertThat("SQL型の検証", columnDescriptor.getColumnType(), is(Types.VARCHAR));
-        assertThat("クラス名の検証", columnDescriptor.getColumnClass().getName(), is(String.class.getName()));
 
         // スキーマ名がnullの場合
         columnDescriptor = sut.getColumnDescriptor(null, "RS_TEST", "CHECK_COL", nativeConnection);
         assertThat("列名の検証", columnDescriptor.getColumnName(), is("CHECK_COL"));
         assertThat("SQL型の検証", columnDescriptor.getColumnType(), is(Types.VARCHAR));
-        assertThat("クラス名の検証", columnDescriptor.getColumnClass().getName(), is(String.class.getName()));
 
         // 存在しない列名を指定
         columnDescriptor = sut.getColumnDescriptor("ssd", "RS_TEST", "DUMMY_COL", nativeConnection);
@@ -116,8 +109,6 @@ public class DataBaseMetaDataCacheTest {
         columnDescriptor = sut.getColumnDescriptor("nablarch", "RS_TEST", "CHECK_COL", nativeConnection);
         assertThat("列名の検証", columnDescriptor.getColumnName(), is("CHECK_COL"));
         assertThat("SQL型の検証", columnDescriptor.getColumnType(), is(Types.NUMERIC));
-        assertThat("クラス名の検証", columnDescriptor.getColumnClass().getName(), is(BigDecimal.class.getName()));
-
     }
 
     // 異常系

--- a/src/test/java/nablarch/core/db/cache/DataBaseMetaDataCacheTest.java
+++ b/src/test/java/nablarch/core/db/cache/DataBaseMetaDataCacheTest.java
@@ -15,7 +15,6 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
 import javax.persistence.*;
-import java.math.BigDecimal;
 import java.sql.*;
 import java.util.Date;
 
@@ -101,10 +100,6 @@ public class DataBaseMetaDataCacheTest {
         assertThat("列名の検証", columnDescriptor.getColumnName(), is("CHECK_COL"));
         assertThat("SQL型の検証", columnDescriptor.getColumnType(), is(Types.VARCHAR));
 
-        // 存在しない列名を指定
-        columnDescriptor = sut.getColumnDescriptor("ssd", "RS_TEST", "DUMMY_COL", nativeConnection);
-        assertThat(columnDescriptor, is(nullValue()));
-
         // 指定したスキーマからデータを取得する
         columnDescriptor = sut.getColumnDescriptor("nablarch", "RS_TEST", "CHECK_COL", nativeConnection);
         assertThat("列名の検証", columnDescriptor.getColumnName(), is("CHECK_COL"));
@@ -149,6 +144,13 @@ public class DataBaseMetaDataCacheTest {
     public void testAbnormalTableForColumnDesc() {
         expectedException.expect(DbAccessException.class);
         sut.getColumnDescriptor("SSD", "DUMMY_TABLE", "VARCHAR_COL", nativeConnection);
+    }
+
+    @Test
+    public void testAbnormalColumnForColumnDesc() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("column not found. column: DUMMY_COL");
+        sut.getColumnDescriptor("SSD", "RS_TEST", "DUMMY_COL", nativeConnection);
     }
 
     @Test

--- a/src/test/java/nablarch/core/db/cache/DataBaseMetaDataCacheTest.java
+++ b/src/test/java/nablarch/core/db/cache/DataBaseMetaDataCacheTest.java
@@ -1,0 +1,223 @@
+package nablarch.core.db.cache;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.assertThat;
+
+import nablarch.core.db.DbAccessException;
+import nablarch.core.db.connection.ConnectionFactory;
+import nablarch.core.db.connection.TransactionManagerConnection;
+import nablarch.core.transaction.TransactionContext;
+import nablarch.test.support.SystemRepositoryResource;
+import nablarch.test.support.db.helper.DatabaseTestRunner;
+import nablarch.test.support.db.helper.VariousDbTestHelper;
+import org.junit.*;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import javax.persistence.*;
+import java.math.BigDecimal;
+import java.sql.*;
+import java.util.Date;
+
+/**
+ * @author ryo asato
+ */
+@RunWith(DatabaseTestRunner.class)
+public class DataBaseMetaDataCacheTest {
+
+    @ClassRule
+    public static SystemRepositoryResource repositoryResource =
+            new SystemRepositoryResource("db-default.xml");
+
+    private final TransactionManagerConnection connection =
+            repositoryResource.getComponentByType(ConnectionFactory.class)
+                    .getConnection(TransactionContext.DEFAULT_TRANSACTION_CONTEXT_KEY);
+
+    private final Connection nativeConnection = connection.getConnection();
+
+    private static DataBaseMetaDataCache sut = DataBaseMetaDataCache.getInstance();
+
+    @BeforeClass
+    public static void setupDatabase() {
+        VariousDbTestHelper.createTable(TestEntity.class);
+        VariousDbTestHelper.createTable(TestEntity2.class);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (connection != null) {
+            connection.terminate();
+        }
+    }
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void testGetTableDescriptor() {
+
+        TableDescriptor tableDescriptor = sut.getTableDescriptor("ssd", "RS_TEST", nativeConnection);
+        // テーブルの情報が取得できる
+        assertThat("テーブル名の検証", tableDescriptor.getTableName(), is("RS_TEST"));
+        // 列情報が取得できる
+        ColumnDescriptor colDescriptor = tableDescriptor.getColumnDescriptor("VARCHAR_COL");
+        assertThat("列名の検証", colDescriptor.getColumnName(), is("VARCHAR_COL"));
+        assertThat("SQL型の検証", colDescriptor.getColumnType(), is(Types.VARCHAR));
+        assertThat("クラス名の検証", colDescriptor.getColumnClass().getName(), is(String.class.getName()));
+
+        colDescriptor = tableDescriptor.getColumnDescriptor("INT_COL");
+        assertThat("列名の検証", colDescriptor.getColumnName(), is("INT_COL"));
+        assertThat("SQL型の検証", colDescriptor.getColumnType(), is(Types.NUMERIC));
+        assertThat("クラス名の検証", colDescriptor.getColumnClass().getName(), is(BigDecimal.class.getName()));
+
+        ColumnDescriptor checkColumnFromSsd = tableDescriptor.getColumnDescriptor("CHECK_COL");
+
+        // スキーマ名がnullの場合
+        tableDescriptor = sut.getTableDescriptor(null, "RS_TEST", nativeConnection);
+        assertThat("テーブル名の検証", tableDescriptor.getTableName(), is("RS_TEST"));
+        colDescriptor = tableDescriptor.getColumnDescriptor("VARCHAR_COL");
+        assertThat("列名の検証", colDescriptor.getColumnName(), is("VARCHAR_COL"));
+        assertThat("SQL型の検証", colDescriptor.getColumnType(), is(Types.VARCHAR));
+        assertThat("クラス名の検証", colDescriptor.getColumnClass().getName(), is(String.class.getName()));
+
+        // 指定したスキーマを参照できるか
+        // ssdスキーマ
+        assertThat("列名の検証", checkColumnFromSsd.getColumnName(), is("CHECK_COL"));
+        assertThat("SQL型の検証", checkColumnFromSsd.getColumnType(), is(Types.VARCHAR));
+        assertThat("クラス名の検証", checkColumnFromSsd.getColumnClass().getName(), is(String.class.getName()));
+        // nablarchスキーマ
+        tableDescriptor = sut.getTableDescriptor("nablarch","RS_TEST", nativeConnection);
+        assertThat("テーブル名の検証", tableDescriptor.getTableName(), is("RS_TEST"));
+        colDescriptor = tableDescriptor.getColumnDescriptor("CHECK_COL");
+        assertThat("列名の検証", colDescriptor.getColumnName(), is("CHECK_COL"));
+        assertThat("SQL型の検証", colDescriptor.getColumnType(), is(Types.NUMERIC));
+        assertThat("クラス名の検証", colDescriptor.getColumnClass().getName(), is(BigDecimal.class.getName()));
+    }
+
+    @Test
+    public void testGetColumnDescriptor() {
+        // 列情報が取得できる
+        ColumnDescriptor columnDescriptor = sut.getColumnDescriptor("ssd", "RS_TEST", "CHECK_COL", nativeConnection);
+        assertThat("列名の検証", columnDescriptor.getColumnName(), is("CHECK_COL"));
+        assertThat("SQL型の検証", columnDescriptor.getColumnType(), is(Types.VARCHAR));
+        assertThat("クラス名の検証", columnDescriptor.getColumnClass().getName(), is(String.class.getName()));
+
+        // スキーマ名がnullの場合
+        columnDescriptor = sut.getColumnDescriptor(null, "RS_TEST", "CHECK_COL", nativeConnection);
+        assertThat("列名の検証", columnDescriptor.getColumnName(), is("CHECK_COL"));
+        assertThat("SQL型の検証", columnDescriptor.getColumnType(), is(Types.VARCHAR));
+        assertThat("クラス名の検証", columnDescriptor.getColumnClass().getName(), is(String.class.getName()));
+
+        // 存在しない列名を指定
+        columnDescriptor = sut.getColumnDescriptor("ssd", "RS_TEST", "DUMMY_COL", nativeConnection);
+        assertThat(columnDescriptor, is(nullValue()));
+
+        // 指定したスキーマからデータを取得する
+        columnDescriptor = sut.getColumnDescriptor("nablarch", "RS_TEST", "CHECK_COL", nativeConnection);
+        assertThat("列名の検証", columnDescriptor.getColumnName(), is("CHECK_COL"));
+        assertThat("SQL型の検証", columnDescriptor.getColumnType(), is(Types.NUMERIC));
+        assertThat("クラス名の検証", columnDescriptor.getColumnClass().getName(), is(BigDecimal.class.getName()));
+
+    }
+
+    // 異常系
+    @Test
+    public void testAbnormalSchemaForTableDesc() {
+        expectedException.expect(DbAccessException.class);
+        sut.getTableDescriptor("DUMMY_SCHEMA", "RS_TEST", nativeConnection);
+    }
+
+    @Test
+    public void testAbnormalTableForTableDesc() {
+        expectedException.expect(DbAccessException.class);
+        expectedException.expectMessage("Can not access to metadata. tablename = DUMMY_TABLE");
+        sut.getTableDescriptor("SSD", "DUMMY_TABLE", nativeConnection);
+    }
+
+    @Test
+    public void testNullTableForTableDesc() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("tableName or connection is null or empty.");
+        sut.getTableDescriptor("SSD", null, nativeConnection);
+    }
+
+    @Test
+    public void testNullConnectionForTableDesc() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("tableName or connection is null or empty.");
+        sut.getTableDescriptor("SSD", "RS_TEST", null);
+    }
+
+    @Test
+    public void testAbnormalSchemaForColumnDesc() {
+        expectedException.expect(DbAccessException.class);
+        sut.getColumnDescriptor("DUMMY_SCHEMA", "RS_TEST", "VARCHAR_COL", nativeConnection);
+    }
+
+    @Test
+    public void testAbnormalTableForColumnDesc() {
+        expectedException.expect(DbAccessException.class);
+        sut.getColumnDescriptor("SSD", "DUMMY_TABLE", "VARCHAR_COL", nativeConnection);
+    }
+
+    @Test
+    public void testNullTableForColumnDesc() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("tableName, columnName or connection is null or empty.");
+        sut.getColumnDescriptor("SSD", null, "VARCHAR_COL", nativeConnection);
+    }
+
+    @Test
+    public void testNullColumnForColumnDesc() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("tableName, columnName or connection is null or empty.");
+        sut.getColumnDescriptor("SSD", "RS_TEST", null, nativeConnection);
+    }
+
+    @Test
+    public void testNullConectionForColumnDesc() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("tableName, columnName or connection is null or empty.");
+        sut.getColumnDescriptor("SSD", "RS_TEST", "VARCHAR_COL", null);
+    }
+
+    @Entity
+    @Table(name = "RS_TEST")
+    public static class TestEntity {
+
+        @Column(name = "varchar_col", length = 5)
+        @Id
+        public String varcharCol;
+
+        @Column(name = "int_col", length = 9)
+        public Integer intCol;
+
+        @Column(name = "date_col")
+        @Temporal(TemporalType.DATE)
+        public Date dateCol;
+
+        @Column(name = "timestamp_col")
+        public Timestamp timestampCol;
+
+        @Column(name = "blob_col")
+        public byte[] blobCol;
+
+        @Column(name = "check_col")
+        public String schemaCheckCol;
+
+        public TestEntity() {
+        }
+    }
+
+    @Entity
+    @Table(name = "nablarch.RS_TEST")
+    public static class TestEntity2 {
+
+        @Column(name = "check_col", length = 1)
+        @Id
+        public Integer schemaCheckCol;
+
+        public TestEntity2() {
+        }
+    }
+}

--- a/src/test/java/nablarch/core/db/cache/TableDescriptorTest.java
+++ b/src/test/java/nablarch/core/db/cache/TableDescriptorTest.java
@@ -1,0 +1,46 @@
+package nablarch.core.db.cache;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.assertThat;
+
+import java.sql.Types;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author ryo asato
+ */
+public class TableDescriptorTest {
+
+    private String tableName = "TEST";
+
+    private Map<String, ColumnDescriptor> columnDescriptorMap;
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void testCaseSensitive() {
+        columnDescriptorMap = new HashMap<String, ColumnDescriptor>();
+        columnDescriptorMap.put("TEST_COLUMN", new ColumnDescriptor("TEST_COLUMN", Types.VARCHAR));
+
+        // 大文字小文字を区別しない場合
+        TableDescriptor sut = new TableDescriptor(tableName, false, columnDescriptorMap);
+        ColumnDescriptor actual = sut.getColumnDescriptor("TEST_COLUMN");
+        assertThat("大文字を指定", actual.getColumnType(), is(Types.VARCHAR));
+        actual = sut.getColumnDescriptor("test_column");
+        assertThat("小文字を指定", actual.getColumnType(), is(Types.VARCHAR));
+
+        // 大文字小文字を区別する場合
+        sut = new TableDescriptor(tableName, true, columnDescriptorMap);
+        actual = sut.getColumnDescriptor("TEST_COLUMN");
+        assertThat("大文字を指定", actual.getColumnType(), is(Types.VARCHAR));
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("column not found. column: test_column");
+        sut.getColumnDescriptor("test_column");
+    }
+}

--- a/src/test/java/nablarch/core/db/dialect/DefaultSqlTypeConverterTest.java
+++ b/src/test/java/nablarch/core/db/dialect/DefaultSqlTypeConverterTest.java
@@ -1,0 +1,33 @@
+package nablarch.core.db.dialect;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.sql.Types;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * {@link DefaultSqlTypeConverter}のテスト
+ * @author ryo asato
+ */
+public class DefaultSqlTypeConverterTest {
+
+    private DefaultSqlTypeConverter sut = new DefaultSqlTypeConverter();
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void convert() {
+        assertTrue("CHARは変換可能", sut.convertToJavaClass(Types.CHAR).isAssignableFrom(String.class));
+    }
+
+    @Test
+    public void convertAbnormalSqlType() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("unsupported sqlType: 12345");
+        sut.convertToJavaClass(12345);
+    }
+}

--- a/src/test/java/nablarch/core/db/dialect/DefaultSqlTypeConverterTest.java
+++ b/src/test/java/nablarch/core/db/dialect/DefaultSqlTypeConverterTest.java
@@ -1,10 +1,13 @@
 package nablarch.core.db.dialect;
 
+import oracle.sql.BLOB;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import java.sql.Types;
+import java.math.BigDecimal;
+import java.net.URL;
+import java.sql.*;
 
 import static org.junit.Assert.assertTrue;
 
@@ -21,7 +24,32 @@ public class DefaultSqlTypeConverterTest {
 
     @Test
     public void convert() {
-        assertTrue("CHARは変換可能", sut.convertToJavaClass(Types.CHAR).isAssignableFrom(String.class));
+        assertTrue(sut.convertToJavaClass(Types.BIT).isAssignableFrom(Boolean.class));
+        assertTrue(sut.convertToJavaClass(Types.TINYINT).isAssignableFrom(Byte.class));
+        assertTrue(sut.convertToJavaClass(Types.SMALLINT).isAssignableFrom(Short.class));
+        assertTrue(sut.convertToJavaClass(Types.INTEGER).isAssignableFrom(Integer.class));
+        assertTrue(sut.convertToJavaClass(Types.BIGINT).isAssignableFrom(Long.class));
+        assertTrue(sut.convertToJavaClass(Types.FLOAT).isAssignableFrom(Double.class));
+        assertTrue(sut.convertToJavaClass(Types.REAL).isAssignableFrom(Float.class));
+        assertTrue(sut.convertToJavaClass(Types.DOUBLE).isAssignableFrom(Double.class));
+        assertTrue(sut.convertToJavaClass(Types.NUMERIC).isAssignableFrom(BigDecimal.class));
+        assertTrue(sut.convertToJavaClass(Types.DECIMAL).isAssignableFrom(BigDecimal.class));
+        assertTrue(sut.convertToJavaClass(Types.CHAR).isAssignableFrom(String.class));
+        assertTrue(sut.convertToJavaClass(Types.VARCHAR).isAssignableFrom(String.class));
+        assertTrue(sut.convertToJavaClass(Types.LONGVARCHAR).isAssignableFrom(String.class));
+        assertTrue(sut.convertToJavaClass(Types.DATE).isAssignableFrom(Date.class));
+        assertTrue(sut.convertToJavaClass(Types.TIME).isAssignableFrom(Time.class));
+        assertTrue(sut.convertToJavaClass(Types.TIMESTAMP).isAssignableFrom(Timestamp.class));
+        assertTrue(sut.convertToJavaClass(Types.BINARY).isAssignableFrom(byte[].class));
+        assertTrue(sut.convertToJavaClass(Types.VARBINARY).isAssignableFrom(byte[].class));
+        assertTrue(sut.convertToJavaClass(Types.LONGVARBINARY).isAssignableFrom(byte[].class));
+        assertTrue(sut.convertToJavaClass(Types.STRUCT).isAssignableFrom(Struct.class));
+        assertTrue(sut.convertToJavaClass(Types.ARRAY).isAssignableFrom(Array.class));
+        assertTrue(sut.convertToJavaClass(Types.BLOB).isAssignableFrom(Blob.class));
+        assertTrue(sut.convertToJavaClass(Types.CLOB).isAssignableFrom(Clob.class));
+        assertTrue(sut.convertToJavaClass(Types.REF).isAssignableFrom(Ref.class));
+        assertTrue(sut.convertToJavaClass(Types.DATALINK).isAssignableFrom(URL.class));
+        assertTrue(sut.convertToJavaClass(Types.BOOLEAN).isAssignableFrom(Boolean.class));
     }
 
     @Test


### PR DESCRIPTION
#13 
各機能を構成するクラスは以下の通りです。

* データベースのメタ情報を取得する機能
  - DataBaseMetaDataCache
  - ColumnDescriptor
  - TableDescriptor
* SQL型からJavaのクラスに変換する機能
  - SqlTypeConverter
  - DefaultSqlTypeConverter