### PR TITLE
H2Dialectの見直し

### DIFF
--- a/src/main/java/nablarch/core/db/dialect/H2Dialect.java
+++ b/src/main/java/nablarch/core/db/dialect/H2Dialect.java
@@ -1,12 +1,14 @@
 package nablarch.core.db.dialect;
 
-import nablarch.core.db.statement.SelectOption;
-
 import java.sql.SQLException;
+
+import nablarch.core.db.statement.SelectOption;
 
 /**
  * H2用のSQL方言クラス。
- *
+ * 
+ * このクラスは、1.4.191により動作確認を行っている。
+ * 
  * @author Masaya Seko
  *
  */

--- a/src/test/java/nablarch/core/db/connection/BasicDbConnectionTest.java
+++ b/src/test/java/nablarch/core/db/connection/BasicDbConnectionTest.java
@@ -14,6 +14,7 @@ import static org.junit.Assert.fail;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.text.MessageFormat;
 import java.util.Arrays;
 import java.util.List;
@@ -1329,6 +1330,7 @@ public class BasicDbConnectionTest {
     }
 
     @Test
+    @TargetDb(exclude = TargetDb.Db.H2)
     public void testPrepareCallBySqlId() throws Exception {
         // ----------------------------------------- cache off
         sut.setStatementReuse(false);
@@ -1365,6 +1367,15 @@ public class BasicDbConnectionTest {
                     format("failed to prepareCallBySqlId. SQL_ID = [%s]", sqlId),
                     e.getMessage());
         }
+    }
+    
+    @Test
+    @TargetDb(include = TargetDb.Db.H2)
+    public void testPrepareCallBySqlId_H2() throws Exception {
+        final Connection connection = sut.getConnection();
+        final Statement statement = connection.createStatement();
+        statement.execute("create alias if not exists proc_name as $$ void procName(String a, String b) {String c = a + b;}$$");
+        testPrepareCallBySqlId();
     }
 
     /**

--- a/src/test/java/nablarch/core/db/statement/BasicSqlPStatementTestLogic.java
+++ b/src/test/java/nablarch/core/db/statement/BasicSqlPStatementTestLogic.java
@@ -1,11 +1,6 @@
 package nablarch.core.db.statement;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
@@ -1982,7 +1977,7 @@ public abstract class BasicSqlPStatementTestLogic {
             mockStatement.setObject(anyInt, any);
             result = new SQLException("setObject error");
         }};
-        final SqlPStatement sut = dbCon.prepareStatement("SELECT * FROM STATEMENT_TEST_TABLE WHERE ID = ?");
+        final SqlPStatement sut = dbCon.prepareStatement("SELECT * FROM STATEMENT_TEST_TABLE WHERE ENTITY_ID = ?");
         Deencapsulation.setField(sut, mockStatement);
         sut.setObject(1, "12345");
     }
@@ -2042,7 +2037,7 @@ public abstract class BasicSqlPStatementTestLogic {
             mockStatement.setObject(anyInt, any, anyInt);
             result = new SQLException("setObjectWithType error");
         }};
-        final SqlPStatement sut = dbCon.prepareStatement("SELECT * FROM STATEMENT_TEST_TABLE WHERE ID = ?");
+        final SqlPStatement sut = dbCon.prepareStatement("SELECT * FROM STATEMENT_TEST_TABLE WHERE ENTITY_ID = ?");
         Deencapsulation.setField(sut, mockStatement);
         sut.setObject(1, "12345", Types.CHAR);
     }
@@ -3333,7 +3328,7 @@ public abstract class BasicSqlPStatementTestLogic {
      * {@link BasicSqlPStatement#getGeneratedKeys()}のテスト。
      */
     @Test
-    @TargetDb(exclude = TargetDb.Db.SQL_SERVER)
+    @TargetDb(exclude = {TargetDb.Db.SQL_SERVER, TargetDb.Db.H2})
     public void getGeneratedKeys() throws Exception {
         final Connection connection = VariousDbTestHelper.getNativeConnection();
         String pkName = "entity_id";
@@ -3366,7 +3361,7 @@ public abstract class BasicSqlPStatementTestLogic {
      * ※SQLServerは、自動生成キーは自動生成カラムのみ対応
      */
     @Test
-    @TargetDb(include = TargetDb.Db.SQL_SERVER)
+    @TargetDb(include = {TargetDb.Db.SQL_SERVER, TargetDb.Db.H2})
     public void getGeneratedKeys_SQLServer() throws Exception {
         VariousDbTestHelper.createTable(SqlServerTestEntity.class);
         final SqlPStatement sut = dbCon.prepareStatement(
@@ -3383,7 +3378,6 @@ public abstract class BasicSqlPStatementTestLogic {
             actual.close();
         }
     }
-
 
     /**
      * {@link BasicSqlPStatement#clearParameters()} のテスト。


### PR DESCRIPTION
H2Dialectの見直し

* 動作確認バージョンを明記
* テスト用のSQLで存在しないカラムを条件にしていたものを修正
* ストアドプロシージャが未定義でテストが落ちていたため、テスト実行前にプロシージャを作成するように修正

#25