### PR TITLE
OracleDialectで対応したコンバータがない場合に例外を発生させる。

### DIFF
--- a/src/main/java/nablarch/core/db/dialect/OracleDialect.java
+++ b/src/main/java/nablarch/core/db/dialect/OracleDialect.java
@@ -230,6 +230,10 @@ public class OracleDialect extends DefaultDialect {
     @SuppressWarnings("unchecked")
     @Override
     protected <T> AttributeConverter<T> getAttributeConverter(final Class<T> javaType) {
-        return (AttributeConverter<T>) ATTRIBUTE_CONVERTER_MAP.get(javaType);
+        AttributeConverter<T> converter = (AttributeConverter<T>) ATTRIBUTE_CONVERTER_MAP.get(javaType);
+        if (converter == null) {
+            throw new IllegalStateException("This dialect does not support [" + javaType.getSimpleName() + "] type.");
+        }
+        return converter;
     }
 }

--- a/src/test/java/nablarch/core/db/dialect/OracleDialectTest.java
+++ b/src/test/java/nablarch/core/db/dialect/OracleDialectTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.text.IsEmptyString.isEmptyString;
 import static org.junit.Assert.assertThat;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.sql.*;
 import java.util.Calendar;
 import java.util.Date;
@@ -444,6 +445,18 @@ public class OracleDialectTest {
         assertThat("Boolean", sut.convertToDatabase(true, Boolean.class), is(Boolean.TRUE));
     }
 
+    /**
+     * DBに出力するとき、
+     * コンバータが設定されていないと例外を送出する。
+     */
+    @Test
+    public void testConvertToDatabaseNotFound() {
+        expectedException.expect(IllegalStateException.class);
+        expectedException.expectMessage("This dialect does not support [BigInteger] type.");
+
+        sut.convertToDatabase(BigInteger.valueOf(100), Integer.class);
+    }
+
     @Test
     public void convertFromDatabase() throws Exception {
         assertThat("String", sut.convertFromDatabase("あああ", String.class), is("あああ"));
@@ -469,6 +482,18 @@ public class OracleDialectTest {
         assertThat("Boolean", sut.convertFromDatabase("on", Boolean.class), is(Boolean.TRUE));
         assertThat("boolean", sut.convertFromDatabase("off", boolean.class), is(false));
         assertThat("null -> boolean", sut.convertFromDatabase(null, boolean.class), is(false));
+    }
+
+    /**
+     * DBから入力を変換するとき、
+     * コンバータが設定されていないと例外を送出する。
+     */
+    @Test
+    public void testConvertFromDatabaseNotFound() {
+        expectedException.expect(IllegalStateException.class);
+        expectedException.expectMessage("This dialect does not support [BigInteger] type.");
+
+        sut.convertFromDatabase("100", BigInteger.class);
     }
 }
 


### PR DESCRIPTION
#28 