### PR TITLE
Timestampのコンストラクタにわたす値を現在のミリ秒に変更

### DIFF
--- a/src/test/java/nablarch/core/db/dialect/PostgreSQLDialectTest.java
+++ b/src/test/java/nablarch/core/db/dialect/PostgreSQLDialectTest.java
@@ -137,7 +137,7 @@ public class PostgreSQLDialectTest {
         calendar.set(2015, 2, 9, 0, 0, 0);
         calendar.set(Calendar.MILLISECOND, 0);
         Date date = calendar.getTime();
-        Timestamp timestamp = new Timestamp(System.nanoTime());
+        Timestamp timestamp = new Timestamp(System.currentTimeMillis());
         VariousDbTestHelper.setUpTable(
                 new DialectEntity(1L, "12345", 100, 1234554321L, date, new BigDecimal("12345.54321"), timestamp,
                         new byte[] {0x00, 0x50, (byte) 0xFF}));


### PR DESCRIPTION
テストの中でjava.sql.Timestampインスタンスを得る際に`Timestamp timestamp = new Timestamp(System.nanoTime());`としていた。
これにより得られるTimestampは"309388-07-19 14:36:39.401000+09"や"301839-10-16 12:51:47.358000+09"のように非常に未来の日付になっており、PostgreSQLが扱える日付の範囲を超えてしまうことがある。

PostgreSQLのドキュメント
https://www.postgresql.org/docs/current/datatype-datetime.html

CI環境でPostgreSQLの日付範囲を超えたことでエラーが発生していたため修正。

CIで発生したエラー
```
[INFO] Running nablarch.core.db.dialect.PostgreSQLDialectTest
[EL Warning]: 2022-02-04 19:37:39.099--UnitOfWork(1354332756)--Exception [EclipseLink-4002] (Eclipse Persistence Services - 2.5.2.v20140319-9ad6abd): org.eclipse.persistence.exceptions.DatabaseException
Internal Exception: org.postgresql.util.PSQLException: ERROR: timestamp out of range: "301839-10-16 12:51:47.358000+09"
Error Code: 0
Call: INSERT INTO DIALECT (entity_id, big_int, binary_col, date_col, decimal_col, num, str, timestamp_col) VALUES (?, ?, ?, ?, ?, ?, ?, ?)

Query: InsertObjectQuery(nablarch.core.db.dialect.DialectEntity@7af86dd8)
[ERROR] Tests run: 15, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.701 s <<< FAILURE! - in nablarch.core.db.dialect.PostgreSQLDialectTest
[ERROR] getResultSetConvertor(nablarch.core.db.dialect.PostgreSQLDialectTest)  Time elapsed: 0.019 s  <<< ERROR!
java.lang.IllegalStateException: 

Exception Description: No transaction is currently active

```