### PR TITLE
feat: H2バージョン更新で発生したエラーを修正しました。

### DIFF
--- a/src/main/java/nablarch/core/db/dialect/H2Dialect.java
+++ b/src/main/java/nablarch/core/db/dialect/H2Dialect.java
@@ -7,7 +7,7 @@ import nablarch.core.db.statement.SelectOption;
 /**
  * H2用のSQL方言クラス。
  * 
- * このクラスは、1.4.191により動作確認を行っている。
+ * このクラスは、2.1.214により動作確認を行っている。
  * 
  * @author Masaya Seko
  *
@@ -18,7 +18,7 @@ public class H2Dialect extends DefaultDialect {
     private static final String UNIQUE_ERROR_SQL_STATE = "23505";
 
     /** Query Timeアウト時に発生する例外のエラーコード */
-    private static final String QUERY_CANCEL_SQL_STATE = "57014";
+    private static final String QUERY_CANCEL_SQL_STATE = "HYT00";
 
     /**
      * {@inheritDoc}
@@ -75,7 +75,7 @@ public class H2Dialect extends DefaultDialect {
      * <p/>
      * H2の場合、以下例外の場合タイムアウト対象の例外として扱う。
      * <ul>
-     * <li>SQLState:57014(query_canceled:クエリタイムアウト時に送出される例外)</li>
+     * <li>SQLState:HYT00(クエリタイムアウト時に送出される例外コード)</li>
      * </ul>
      */
     @Override

--- a/src/main/java/nablarch/core/db/dialect/H2Dialect.java
+++ b/src/main/java/nablarch/core/db/dialect/H2Dialect.java
@@ -7,7 +7,7 @@ import nablarch.core.db.statement.SelectOption;
 /**
  * H2用のSQL方言クラス。
  * 
- * このクラスは、2.1.214により動作確認を行っている。
+ * このクラスは、1.4.191 および 2.1.214 により動作確認を行っている。
  * 
  * @author Masaya Seko
  *
@@ -18,7 +18,10 @@ public class H2Dialect extends DefaultDialect {
     private static final String UNIQUE_ERROR_SQL_STATE = "23505";
 
     /** Query Timeアウト時に発生する例外のエラーコード */
-    private static final String QUERY_CANCEL_SQL_STATE = "HYT00";
+    private static final String QUERY_CANCEL_SQL_STATE = "57014";
+
+    /** 2.1.214 でロック試行タイムアウト時に発生する例外のエラーコード */
+    private static final String TIMEOUT_TRYING_TO_LOCK_TABLE = "HYT00";
 
     /**
      * {@inheritDoc}
@@ -75,13 +78,14 @@ public class H2Dialect extends DefaultDialect {
      * <p/>
      * H2の場合、以下例外の場合タイムアウト対象の例外として扱う。
      * <ul>
-     * <li>SQLState:HYT00(クエリタイムアウト時に送出される例外コード)</li>
+     * <li>SQLState:57014(クエリタイムアウト時に送出される例外コード)</li>
+     * <li>SQLState:HYT00(ロック試行タイムアウト時に送出される例外コード)</li>
      * </ul>
      */
     @Override
     public boolean isTransactionTimeoutError(SQLException sqlException) {
         final String sqlState = sqlException.getSQLState();
-        return QUERY_CANCEL_SQL_STATE.equals(sqlState);
+        return QUERY_CANCEL_SQL_STATE.equals(sqlState) || TIMEOUT_TRYING_TO_LOCK_TABLE.equals(sqlState);
     }
 
     /**

--- a/src/main/java/nablarch/core/db/dialect/H2Dialect.java
+++ b/src/main/java/nablarch/core/db/dialect/H2Dialect.java
@@ -21,7 +21,7 @@ public class H2Dialect extends DefaultDialect {
     private static final String QUERY_CANCEL_SQL_STATE = "57014";
 
     /** 2.1.214 でロック試行タイムアウト時に発生する例外のエラーコード */
-    private static final String TIMEOUT_TRYING_TO_LOCK_TABLE = "HYT00";
+    private static final String LOCK_TIMEOUT_SQL_STATE = "HYT00";
 
     /**
      * {@inheritDoc}
@@ -85,7 +85,7 @@ public class H2Dialect extends DefaultDialect {
     @Override
     public boolean isTransactionTimeoutError(SQLException sqlException) {
         final String sqlState = sqlException.getSQLState();
-        return QUERY_CANCEL_SQL_STATE.equals(sqlState) || TIMEOUT_TRYING_TO_LOCK_TABLE.equals(sqlState);
+        return QUERY_CANCEL_SQL_STATE.equals(sqlState) || LOCK_TIMEOUT_SQL_STATE.equals(sqlState);
     }
 
     /**

--- a/src/test/java/nablarch/core/db/dialect/H2DialectTest.java
+++ b/src/test/java/nablarch/core/db/dialect/H2DialectTest.java
@@ -119,6 +119,9 @@ public class H2DialectTest {
 
         assertThat("SQLStateが HYT00 なのでトランザクションタイムアウトの対象",
                 sut.isTransactionTimeoutError(new SQLException("", "HYT00")), is(true));
+
+        assertThat("SQLStateが 57014 でなく、HYT00 でもないのでトランザクションタイムアウトの対象ではない",
+                sut.isTransactionTimeoutError(new SQLException("", "HYT01")), is(false));
     }
 
     /**

--- a/src/test/java/nablarch/core/db/dialect/H2DialectTest.java
+++ b/src/test/java/nablarch/core/db/dialect/H2DialectTest.java
@@ -109,16 +109,16 @@ public class H2DialectTest {
     /**
      * {@link H2Dialect#isTransactionTimeoutError(SQLException)}のテスト。
      * <p/>
-     * SQLStateが、HYT00の場合にトランザクションタイムアウト例外となる。
+     * SQLStateが、57014およびHYT00の場合にトランザクションタイムアウト例外となる。
      */
     @Test
     public void isTransactionTimeoutError() {
 
+        assertThat("SQLStateが 57014 なのでトランザクションタイムアウトの対象",
+                sut.isTransactionTimeoutError(new SQLException("", "57014")), is(true));
+
         assertThat("SQLStateが HYT00 なのでトランザクションタイムアウトの対象",
                 sut.isTransactionTimeoutError(new SQLException("", "HYT00")), is(true));
-
-        assertThat("SQLStateが HYT00 以外の場合は、トランザクションタイムアウトではない",
-                sut.isTransactionTimeoutError(new SQLException("", "HYC00")), is(false));
     }
 
     /**

--- a/src/test/java/nablarch/core/db/dialect/H2DialectTest.java
+++ b/src/test/java/nablarch/core/db/dialect/H2DialectTest.java
@@ -109,18 +109,16 @@ public class H2DialectTest {
     /**
      * {@link H2Dialect#isTransactionTimeoutError(SQLException)}のテスト。
      * <p/>
-     * SQLStateが、57014の場合にトランザクションタイムアウト例外となる。
+     * SQLStateが、HYT00の場合にトランザクションタイムアウト例外となる。
      */
     @Test
-    public void isTransactionTimeoutError() throws Exception {
+    public void isTransactionTimeoutError() {
 
-        assertThat("SQLStateが57014なのでトランザクションタイムアウトの対象",
-                sut.isTransactionTimeoutError(new SQLException("", "57014")), is(true));
+        assertThat("SQLStateが HYT00 なのでトランザクションタイムアウトの対象",
+                sut.isTransactionTimeoutError(new SQLException("", "HYT00")), is(true));
 
-        assertThat("ロックタイムアウトのSQLStateである50200は対象外",
-                sut.isTransactionTimeoutError(new SQLException("", "50200")), is(false));
-
-        assertThat("エラーコードが57014は対象外", sut.isTransactionTimeoutError(new SQLException("", "", 57014)), is(false));
+        assertThat("SQLStateが HYT00 以外の場合は、トランザクションタイムアウトではない",
+                sut.isTransactionTimeoutError(new SQLException("", "HYC00")), is(false));
     }
 
     /**

--- a/src/test/java/nablarch/core/db/statement/BasicSqlPStatementOnTransactionTimeoutTest.java
+++ b/src/test/java/nablarch/core/db/statement/BasicSqlPStatementOnTransactionTimeoutTest.java
@@ -132,6 +132,14 @@ public class BasicSqlPStatementOnTransactionTimeoutTest {
         statement.retrieve();
     }
 
+    /** SQL実行時にクエリータイムアウトしていた場合 */
+    @Test(expected = TransactionTimeoutException.class)
+    public void testRetrievePreQueryTimeout() {
+        SqlPStatement statement = dbConnection.prepareStatement(
+                "SELECT MAX(RAND()) FROM SYSTEM_RANGE(1, 100000000)");
+        statement.retrieve();
+    }
+
     /** SQL実行中にタイムアウトした場合 */
     @Test(expected = TransactionTimeoutException.class)
     public void testRetrieveAfterTimeout() throws Throwable {

--- a/src/test/java/nablarch/core/db/statement/BasicSqlPStatementOnTransactionTimeoutTest.java
+++ b/src/test/java/nablarch/core/db/statement/BasicSqlPStatementOnTransactionTimeoutTest.java
@@ -132,17 +132,17 @@ public class BasicSqlPStatementOnTransactionTimeoutTest {
         statement.retrieve();
     }
 
-    /** SQL実行時にクエリータイムアウトしていた場合 */
+    /** SQL実行中にタイムアウトした場合(応答時間が長いクエリ) */
     @Test(expected = TransactionTimeoutException.class)
-    public void testRetrievePreQueryTimeout() {
+    public void testRetrieveAfterTimeoutByLongQuery() {
         SqlPStatement statement = dbConnection.prepareStatement(
                 "SELECT MAX(RAND()) FROM SYSTEM_RANGE(1, 100000000)");
         statement.retrieve();
     }
 
-    /** SQL実行中にタイムアウトした場合 */
+    /** SQL実行中にタイムアウトした場合(ロック試行のタイムアウト) */
     @Test(expected = TransactionTimeoutException.class)
-    public void testRetrieveAfterTimeout() throws Throwable {
+    public void testRetrieveAfterTimeoutByLockTimeout() throws Throwable {
         new TransactionTimeoutCaseExecutor() {
             @Override
             void execute(BasicDbConnection connection) {

--- a/src/test/java/nablarch/core/db/statement/BasicSqlPStatementTestLogic.java
+++ b/src/test/java/nablarch/core/db/statement/BasicSqlPStatementTestLogic.java
@@ -83,7 +83,7 @@ public abstract class BasicSqlPStatementTestLogic {
     @Table(name="statement_test_sqlserver")
     private static class SqlServerTestEntity {
         @Id
-        @Column(name = "id", columnDefinition = "bigint identity")
+        @Column(name = "id", columnDefinition = "bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY")
         public Long id;
 
         @Column(name = "name", columnDefinition = "nvarchar(100)")
@@ -1790,7 +1790,7 @@ public abstract class BasicSqlPStatementTestLogic {
     @Test
     public void setTime() throws Exception {
         Calendar calendar = Calendar.getInstance();
-        calendar.set(0, 0, 0, 1, 2, 3);
+        calendar.set(1970, 1, 1, 1, 2, 3);
         calendar.set(Calendar.MILLISECOND, 0);
         final Time insertTime = new Time(calendar.getTimeInMillis());
 
@@ -1814,7 +1814,7 @@ public abstract class BasicSqlPStatementTestLogic {
     @Test
     public void setTime_writeSqlLog() throws Exception {
         Calendar calendar = Calendar.getInstance();
-        calendar.set(0, 0, 0, 1, 2, 3);
+        calendar.set(1970, 1, 1, 1, 2, 3);
         calendar.set(Calendar.MILLISECOND, 0);
         final Time insertTime = new Time(calendar.getTimeInMillis());
 


### PR DESCRIPTION
## 変更内容

H2のバージョンを 2.1.214 に更新したことで、CIでエラーが発生したため、修正しました。

### 発生エラー1

[ERROR] Tests run: 208, Failures: 1, Errors: 1, Skipped: 4, Time elapsed: 9.39 s <<< FAILURE! - in nablarch.core.db.cache.statement.CacheableSqlPStatementCompatibilityTest
[ERROR] getGeneratedKeys_SQLServer(nablarch.core.db.cache.statement.CacheableSqlPStatementCompatibilityTest)  Time elapsed: 0.023 s  <<< ERROR!
java.lang.RuntimeException: 
Exception [EclipseLink-4002] (Eclipse Persistence Services - 2.5.2.v20140319-9ad6abd): org.eclipse.persistence.exceptions.DatabaseException
Internal Exception: org.h2.jdbc.JdbcSQLSyntaxErrorException: SQLステートメントに文法エラーがあります "CREATE TABLE statement_test_sqlserver (id bigint [*]identity, name nvarchar(100), PRIMARY KEY (id))"; 期待されるステートメント "ARRAY, INVISIBLE, VISIBLE, NOT NULL, NULL, AS, DEFAULT, GENERATED, ON UPDATE, NOT NULL, NULL, AUTO_INCREMENT, DEFAULT ON NULL, NULL_TO_DEFAULT, SEQUENCE, SELECTIVITY, COMMENT, CONSTRAINT, COMMENT, PRIMARY KEY, UNIQUE, NOT NULL, NULL, CHECK, REFERENCES, AUTO_INCREMENT, ,, )"

### 原因

H2バージョン更新にともない、IDENTITYを使った文法に変更があったため。

https://github.com/h2database/h2database/issues/3326

### 修正内容

GENERATED ALWAYS AS IDENTITY PRIMARY KEY

を使用するよう修正しました。

## 発生エラー2

[ERROR] setTime(nablarch.core.db.cache.statement.CacheableSqlPStatementCompatibilityTest)  Time elapsed: 0.01 s  <<< FAILURE!
java.lang.AssertionError: 
Timeが登録されること
Expected: is "01:02:03"
     but: was "01:21:02"

### 原因

Calendarインスタンスの年月日の部分に 0年0月0日を指定していたため、予測できない動作をした。

### 修正内容

1970年1月1日を指定するよう修正しました。

## 発生エラー3

[ERROR] Tests run: 38, Failures: 0, Errors: 12, Skipped: 2, Time elapsed: 404.737 s <<< FAILURE! - in nablarch.core.db.statement.BasicSqlPStatementOnTransactionTimeoutTest
[ERROR] testExecuteUpdateObjectAfterTimeout(nablarch.core.db.statement.BasicSqlPStatementOnTransactionTimeoutTest)  Time elapsed: 31.117 s  <<< ERROR!
java.lang.Exception: Unexpected exception, expected<nablarch.core.transaction.TransactionTimeoutException> but was<nablarch.core.db.statement.exception.SqlStatementException>
Caused by: nablarch.core.db.statement.exception.SqlStatementException: failed to executeUpdate. SQL = [UPDATE TIMEOUT_TEST SET COL1 = '1' WHERE COL1 = ?]
Caused by: org.h2.jdbc.JdbcSQLTimeoutException: 
テーブル {0} のロック試行がタイムアウトしました

### 原因

H2バージョン更新にともない、存在しないテーブルに対しての試行がタイムアウトした場合にH2が返すコードが、

57014(ステートメントがキャンセルされたか、セッションがタイムアウトしました)

から

HYT00(テーブル {0} のロック試行がタイムアウトしました)

に変更されたため。

### 修正内容

コードの値をHYT00に変更しました。