### PR TITLE
test: SQLServerでのDATE型のテストケースを修正

### DIFF
--- a/src/test/java/nablarch/core/db/dialect/SqlServerDialectTest.java
+++ b/src/test/java/nablarch/core/db/dialect/SqlServerDialectTest.java
@@ -166,7 +166,7 @@ public class SqlServerDialectTest {
         assertThat("10桁以上の数値型はLongで取得できる", (Long) convertor.convert(rs, meta, 4), is(Long.valueOf("1234554321")));
         assertThat("小数部ありはBigDecimalで取得できる", (BigDecimal) convertor.convert(rs, meta, 5), is(new BigDecimal(
                 "12345.54321")));
-        assertThat("DATE型はTimestampで取得できる", (Timestamp) convertor.convert(rs, meta, 6), is(new Timestamp(date.getTime())));
+        assertThat("DATE型はjava.sql.Dateで取得できる", (java.sql.Date) convertor.convert(rs, meta, 6), is(new java.sql.Date(date.getTime())));
         assertThat("TIMESTAMP型はTimestampで取得できる", (Timestamp) convertor.convert(rs, meta, 7), is(timestamp));
 
         // binaryはbyte[]で取得される


### PR DESCRIPTION
## 起こった問題

Eclipselink のバージョンを上げたことで、 SQLServer でのテストにおいて以下のエラーが発生するようになった。

```
[INFO] Running nablarch.core.db.dialect.SqlServerDialectTest
[ERROR] Tests run: 12, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.493 s <<< FAILURE! - in nablarch.core.db.dialect.SqlServerDialectTest
[ERROR] getResultSetConvertor(nablarch.core.db.dialect.SqlServerDialectTest)  Time elapsed: 0.018 s  <<< ERROR!
java.lang.ClassCastException: class java.sql.Date cannot be cast to class java.sql.Timestamp (java.sql.Date and java.sql.Timestamp are in module java.sql of loader 'platform')
	at nablarch.core.db.dialect.SqlServerDialectTest.getResultSetConvertor(SqlServerDialectTest.java:169)
```

エラー箇所のテストコードは以下（[実装箇所](https://github.com/nablarch/nablarch-core-jdbc/blob/1.6.0/src/test/java/nablarch/core/db/dialect/SqlServerDialectTest.java#L169)）。

```java
assertThat("DATE型はTimestampで取得できる", (Timestamp) convertor.convert(rs, meta, 6), is(new Timestamp(date.getTime())));
```

`convertor.convert()` の戻り値を `Timestamp` にキャストしようとしているが、 `convert` メソッドが返したオブジェクトが `java.sql.Date` になっており `ClassCastException` が発生している。
（`convert` メソッドの内部では、 `rs` (`ResultSet`) から `getObject` した結果を返している）

## 原因

問題が発生しているテストで使用しているテーブルは、Eclipselink を使ってエンティティクラス(`SqlServerDialectEntity`)のメタ情報などを元に生成している。
エラーになっているカラムに対応するエンティティのフィールドには `@Temporal(TemporalType.DATE)` が設定されており、Eclipselinkには `java.sql.Date` 型としてメタ情報が連携される（[ここ](https://github.com/nablarch/nablarch-test-support/blob/0.3.0/src/main/java/nablarch/test/support/db/helper/VariousDbTestHelper.java#L138)で、アノテーションの情報をもとにフィールドの型を設定している）。

Eclipselink はエンティティからテーブルを生成する際、フィールドの型を元にカラムの型を決定している。
Eclipselink 更新前(2.5.2)は、フィールドの型が `java.sql.Date` の場合はカラムの型を `DATETIME` 型にしていた。
しかし更新後(4.0.1)は、フィールドの型が `java.sql.Date` の場合はカラムの型を `DATE` 型にするように変わった。

- [Eclipselink 2.5.2](https://github.com/eclipse-ee4j/eclipselink/blob/2.5.2/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/platform/database/SQLServerPlatform.java#L166)
- [Eclipselink 4.0.1](https://github.com/eclipse-ee4j/eclipselink/blob/4.0.1/foundation/org.eclipse.persistence.core/src/main/java/org/eclipse/persistence/platform/database/SQLServerPlatform.java#L249)

DB のテーブルのカラムが `DATETIME` 型の場合、 JDBC で `getObject` した結果は `Timestamp` 型になる。
一方で、 `DATE` 型の場合は JDBC で `getObject` した結果は `java.sql.Date` 型になる。

この結果、上述のテストで `ClassCastException` が発生するようになった。

## 対応内容

テストケースで `Timestamp` にキャストするのをやめて、 `java.sql.Date` で受け取る形に修正。

以下、考え方について説明する。

そもそも、本テストケースは以下のことを確認しようとしている。

- DB のカラムの型が `DATE` 型だった場合に、 `SqlServerResultSetConvertor` が変換した結果は何であるべきか

しかし、現行(修正前)は `java.sql.Date` 型に対して `DATETIME` 型のカラムでテーブルを生成してしまっているので、この観点でのテストができていないことになる。
おそらく、「`java.sql.Date` 型に対して生成されるテーブルのカラムは `DATE` 型のはず」→「動かした結果 `Timestamp` を返したから、 SQLServer は `DATE` 型のカラムの場合は `Timestamp` を返す」という誤った推測をしてテストケースを作成したのではないかと考えられる。
（実際には `java.sql.Date` の型に対して作成されるカラムの型は `DATETIME` 型になっており、前提が誤っていた）

Eclipselink の挙動が修正されたことにより、このテストケースは本来確認したかった条件で動くようになったと考えることができる。

したがって、テストコードの方のキャストを `java.sql.Date` に変えることにした。

## 既存(5系)のコードに関して

既存のテストコードは、本来確認しようとしている観点でのテストができていないと考えられる。

本来の観点でテストをできるようにするためには、生成されるテーブルのカラムの型を `DATE` 型にする必要がある。
しかし、上述の Eclipselink の Java の型に対するカラムの型を定義している[メソッドの実装](https://github.com/eclipse-ee4j/eclipselink/blob/2.5.2/foundation/org.eclipse.persistence.core/src/org/eclipse/persistence/platform/database/SQLServerPlatform.java#L140)を見ると、 `DATE` 型にマッピングできる Java の型は存在しないことが分かる。

一方で、 Java の型から推測するのではなく、直接カラムの型を指定する方法も用意されている。
以下は、 nablarch-test-support の `VariousDbTestHelper` で実際に直接カラム型を指定しているところで、 `setTypeDefinition` メソッドで設定しているのが分かる。

https://github.com/nablarch/nablarch-test-support/blob/0.3.0/src/main/java/nablarch/test/support/db/helper/VariousDbTestHelper.java#L150

この実装は、ちょうど問題となっているテーブル生成のメソッドで、 SQLServer のバイナリ型の場合の特別処理を書いているところになる。

既存(5系)のコードでこの問題に対応する場合は、この実装と同じように「SQLServer でかつ Java の型を `java.sql.Date` 型とする場合は、 `DATE` 型を明示的に設定する」という処理を入れる必要があると考えられる。
（`@Temporal` アノテーションを見て `setType` しているところがあるが、そこに SQLServer の場合だけの処理を追加する）
