### PR TITLE
fix: SQLServerでDATE型のカラムの値がTimestampで取得できることを期待していたテストをjava.sql.Dateを期待するように修正

### DIFF
--- a/src/test/java/nablarch/core/db/dialect/SqlServerDialectTest.java
+++ b/src/test/java/nablarch/core/db/dialect/SqlServerDialectTest.java
@@ -166,7 +166,7 @@ public class SqlServerDialectTest {
         assertThat("10桁以上の数値型はLongで取得できる", (Long) convertor.convert(rs, meta, 4), is(Long.valueOf("1234554321")));
         assertThat("小数部ありはBigDecimalで取得できる", (BigDecimal) convertor.convert(rs, meta, 5), is(new BigDecimal(
                 "12345.54321")));
-        assertThat("DATE型はTimestampで取得できる", (Timestamp) convertor.convert(rs, meta, 6), is(new Timestamp(date.getTime())));
+        assertThat("DATE型はjava.sql.Dateで取得できる", (java.sql.Date) convertor.convert(rs, meta, 6), is(new java.sql.Date(date.getTime())));
         assertThat("TIMESTAMP型はTimestampで取得できる", (Timestamp) convertor.convert(rs, meta, 7), is(timestamp));
 
         // binaryはbyte[]で取得される


### PR DESCRIPTION
[こちらの修正](https://github.com/nablarch/nablarch-test-support/pull/25)で、 `TemporalType.DATE` をつけたフィールドに対応するカラムの型が `DATE` で生成されるようになり、 `convert` が `java.sql.Date` を返すようになるので、それに合わせて修正。