### PR TITLE
test: jmockit -> mockito

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,8 +57,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.jmockit</groupId>
-      <artifactId>jmockit</artifactId>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/src/main/java/nablarch/core/db/util/DbUtil.java
+++ b/src/main/java/nablarch/core/db/util/DbUtil.java
@@ -139,6 +139,7 @@ public final class DbUtil {
             field.setAccessible(true);
             return field.get(data);
         } catch (IllegalAccessException e) {
+            // setAccessible(true) でアクセス可能にしているので、この例外がスローされることはない
             throw new RuntimeException(String.format(
                     "failed to access the filed [%s]  of the class [%s].",
                     fieldName, data.getClass().getName()) ,e);

--- a/src/test/java/nablarch/core/db/DbExecutionContextTest.java
+++ b/src/test/java/nablarch/core/db/DbExecutionContextTest.java
@@ -1,17 +1,15 @@
 package nablarch.core.db;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.sameInstance;
-import static org.junit.Assert.assertThat;
-
 import nablarch.core.db.connection.AppDbConnection;
 import nablarch.core.db.connection.TransactionManagerConnection;
 import nablarch.core.db.dialect.DefaultDialect;
 import nablarch.core.db.dialect.Dialect;
-
 import org.junit.Test;
 
-import mockit.Mocked;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
 
 
 /**
@@ -20,8 +18,7 @@ import mockit.Mocked;
  * @author tani takanori
  */
 public class DbExecutionContextTest {
-    @Mocked
-    private TransactionManagerConnection connection;
+    private final TransactionManagerConnection connection = mock(TransactionManagerConnection.class);
 
     private Dialect dialect = new DefaultDialect();
 

--- a/src/test/java/nablarch/core/db/cache/statement/CacheableStatementFactoryTest.java
+++ b/src/test/java/nablarch/core/db/cache/statement/CacheableStatementFactoryTest.java
@@ -1,26 +1,11 @@
 package nablarch.core.db.cache.statement;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
-
-import java.math.BigDecimal;
-import java.sql.Connection;
-import java.sql.SQLException;
-import java.sql.Timestamp;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.Temporal;
 import jakarta.persistence.TemporalType;
-
 import nablarch.core.ThreadContext;
 import nablarch.core.cache.expirable.BasicExpirationSetting;
 import nablarch.core.db.DbExecutionContext;
@@ -41,7 +26,6 @@ import nablarch.core.util.Builder;
 import nablarch.test.support.SystemRepositoryResource;
 import nablarch.test.support.db.helper.DatabaseTestRunner;
 import nablarch.test.support.db.helper.VariousDbTestHelper;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -49,7 +33,20 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import mockit.Mocked;
+import java.math.BigDecimal;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
 
 
 /**
@@ -297,7 +294,8 @@ public class CacheableStatementFactoryTest {
 
     /** プロパティresultSetCacheが設定されていない場合、例外が発生すること。 */
     @Test(expected = IllegalStateException.class)
-    public void testResultSetCacheNotSet(@Mocked Connection mockConnection) throws SQLException {
+    public void testResultSetCacheNotSet() throws SQLException {
+        Connection mockConnection = mock(Connection.class);
         CacheableStatementFactory target = new CacheableStatementFactory();
         target.setExpirationSetting(new BasicExpirationSetting());
         target.getParameterizedSqlPStatementBySqlId("SQL", mockConnection, context);
@@ -305,7 +303,8 @@ public class CacheableStatementFactoryTest {
 
     /** プロパティexpirationSettingが設定されていない場合、例外が発生すること。 */
     @Test(expected = IllegalStateException.class)
-    public void testExpirationSettingNotSet(@Mocked Connection mockConnection) throws SQLException {
+    public void testExpirationSettingNotSet() throws SQLException {
+        Connection mockConnection = mock(Connection.class);
         CacheableStatementFactory target = new CacheableStatementFactory();
         target.setResultSetCache(new InMemoryResultSetCache());
         target.getParameterizedSqlPStatementBySqlId("SQL", mockConnection, context);

--- a/src/test/java/nablarch/core/db/connection/BasicDbConnectionFactoryForJndiTest.java
+++ b/src/test/java/nablarch/core/db/connection/BasicDbConnectionFactoryForJndiTest.java
@@ -1,30 +1,32 @@
 package nablarch.core.db.connection;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import nablarch.core.db.DbExecutionContext;
+import nablarch.core.db.connection.exception.DbConnectionException;
+import nablarch.core.db.statement.BasicStatementFactory;
+import nablarch.core.db.statement.SqlPStatement;
+import nablarch.core.transaction.TransactionContext;
+import org.junit.Test;
+import org.mockito.MockedConstruction;
 
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
-import javax.naming.InitialContext;
-import javax.naming.NamingException;
-import javax.sql.DataSource;
-
-import nablarch.core.db.DbExecutionContext;
-import nablarch.core.db.connection.exception.DbConnectionException;
-import nablarch.core.db.statement.BasicStatementFactory;
-import nablarch.core.db.statement.SqlPStatement;
-import nablarch.core.transaction.TransactionContext;
-
-import org.junit.Ignore;
-import org.junit.Test;
-
-import mockit.Expectations;
-import mockit.Mocked;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.when;
 
 
 /**
@@ -32,23 +34,15 @@ import mockit.Mocked;
  *
  * @author Hisaaki Sioiri
  */
-@Ignore("jacoco と jmockit が競合してエラーになるため")
 public class BasicDbConnectionFactoryForJndiTest {
 
-    @Mocked
-    private InitialContext jndiContext;
+    private final DataSource dataSource = mock(DataSource.class);
 
-    @Mocked
-    private DataSource dataSource;
+    private final Connection con = mock(Connection.class, RETURNS_DEEP_STUBS);
 
-    @Mocked
-    private Connection con;
+    private final DbExecutionContext context = mock(DbExecutionContext.class);
 
-    @Mocked
-    private DbExecutionContext context;
-
-    @Mocked
-    private DbAccessExceptionFactory exceptionFactory;
+    private final DbAccessExceptionFactory exceptionFactory = mock(DbAccessExceptionFactory.class);
 
     private static final String CONNECTION_NAME = TransactionContext.DEFAULT_TRANSACTION_CONTEXT_KEY;
 
@@ -64,21 +58,18 @@ public class BasicDbConnectionFactoryForJndiTest {
     public void testGetConnectionDefaultInitialContext() throws Exception {
         // jndiから取得されるdataSource、connectionの設定を行う。
         final String lookupName = "nablarch_test";
-        new Expectations() {{
-            jndiContext.lookup(lookupName);
-            result = dataSource;
-        }};
-        new Expectations() {{
-            dataSource.getConnection();
-            result = con;
-        }};
+        try (final MockedConstruction<InitialContext> mocked = mockConstruction(InitialContext.class, (mock, context) -> {
+            when(mock.lookup(lookupName)).thenReturn(dataSource);
+        })) {
+            when(dataSource.getConnection()).thenReturn(con);
 
-        BasicDbConnectionFactoryForJndi forJndi = new BasicDbConnectionFactoryForJndi();
-        forJndi.setJndiResourceName(lookupName);
+            BasicDbConnectionFactoryForJndi forJndi = new BasicDbConnectionFactoryForJndi();
+            forJndi.setJndiResourceName(lookupName);
 
-        TransactionManagerConnection connection = forJndi.getConnection(CONNECTION_NAME);
-        assertThat(connection, instanceOf(BasicDbConnection.class));
-        assertThat(((BasicDbConnection) connection).getConnection(), is(con));
+            TransactionManagerConnection connection = forJndi.getConnection(CONNECTION_NAME);
+            assertThat(connection, instanceOf(BasicDbConnection.class));
+            assertThat(((BasicDbConnection) connection).getConnection(), is(con));
+        }
     }
 
     /**
@@ -97,20 +88,20 @@ public class BasicDbConnectionFactoryForJndiTest {
         final String lookupName = "test";
         final Properties jndiProp = new Properties();
         jndiProp.putAll(property);
-        new Expectations() {{
-            jndiContext.lookup(lookupName);
-            result = dataSource;
-            dataSource.getConnection();
-            result = con;
-        }};
 
-        BasicDbConnectionFactoryForJndi forJndi = new BasicDbConnectionFactoryForJndi();
-        forJndi.setJndiResourceName(lookupName);
-        forJndi.setJndiProperties(property);
+        try (final MockedConstruction<InitialContext> mocked = mockConstruction(InitialContext.class, (mock, context) -> {
+            when(mock.lookup(lookupName)).thenReturn(dataSource);
+        })) {
+            when(dataSource.getConnection()).thenReturn(con);
 
-        TransactionManagerConnection connection = forJndi.getConnection(CONNECTION_NAME);
-        assertThat(connection, instanceOf(BasicDbConnection.class));
-        assertThat(((BasicDbConnection) connection).getConnection(), is(con));
+            BasicDbConnectionFactoryForJndi forJndi = new BasicDbConnectionFactoryForJndi();
+            forJndi.setJndiResourceName(lookupName);
+            forJndi.setJndiProperties(property);
+
+            TransactionManagerConnection connection = forJndi.getConnection(CONNECTION_NAME);
+            assertThat(connection, instanceOf(BasicDbConnection.class));
+            assertThat(((BasicDbConnection) connection).getConnection(), is(con));
+        }
     }
 
     /**
@@ -121,26 +112,22 @@ public class BasicDbConnectionFactoryForJndiTest {
     @Test
     public void testStatementReuseDefault() throws Exception {
         final String lookupName = "nablarch_test";
-        new Expectations() {{
-            jndiContext.lookup(lookupName);
-            result = dataSource;
-        }};
-        new Expectations() {{
-            dataSource.getConnection();
-            result = con;
-        }};
+        try (final MockedConstruction<InitialContext> mocked = mockConstruction(InitialContext.class, (mock, context) -> {
+            when(mock.lookup(lookupName)).thenReturn(dataSource);
+        })) {
+            when(dataSource.getConnection()).thenReturn(con);
 
-        BasicDbConnectionFactoryForJndi forJndi = new BasicDbConnectionFactoryForJndi();
-        forJndi.setJndiResourceName(lookupName);
-        forJndi.setStatementFactory(new BasicStatementFactory());
-        TransactionManagerConnection connection = forJndi.getConnection(CONNECTION_NAME);
+            BasicDbConnectionFactoryForJndi forJndi = new BasicDbConnectionFactoryForJndi();
+            forJndi.setJndiResourceName(lookupName);
+            forJndi.setStatementFactory(new BasicStatementFactory());
+            TransactionManagerConnection connection = forJndi.getConnection(CONNECTION_NAME);
 
-        String sql = "SELECT * FROM TEST_TABLE";
-        SqlPStatement statement1 = connection.prepareStatement(sql);
-        SqlPStatement statement2 = connection.prepareStatement(sql);
-        assertThat("デフォルト設定でSqlPStatementが同一のものが返ってくる。",
-                statement1, is(statement2));
-
+            String sql = "SELECT * FROM TEST_TABLE";
+            SqlPStatement statement1 = connection.prepareStatement(sql);
+            SqlPStatement statement2 = connection.prepareStatement(sql);
+            assertThat("デフォルト設定でSqlPStatementが同一のものが返ってくる。",
+                    statement1, is(statement2));
+        }
     }
 
     /**
@@ -151,27 +138,23 @@ public class BasicDbConnectionFactoryForJndiTest {
     @Test
     public void testStatementReuseFalse() throws Exception {
         final String lookupName = "nablarch_test";
-        new Expectations() {{
-            jndiContext.lookup(lookupName);
-            result = dataSource;
-        }};
-        new Expectations() {{
-            dataSource.getConnection();
-            result = con;
-        }};
+        try (final MockedConstruction<InitialContext> mocked = mockConstruction(InitialContext.class, (mock, context) -> {
+            when(mock.lookup(lookupName)).thenReturn(dataSource);
+        })) {
+            when(dataSource.getConnection()).thenReturn(con);
 
-        BasicDbConnectionFactoryForJndi forJndi = new BasicDbConnectionFactoryForJndi();
-        forJndi.setJndiResourceName(lookupName);
-        forJndi.setStatementFactory(new BasicStatementFactory());
-        forJndi.setStatementReuse(false);
-        TransactionManagerConnection connection = forJndi.getConnection(CONNECTION_NAME);
+            BasicDbConnectionFactoryForJndi forJndi = new BasicDbConnectionFactoryForJndi();
+            forJndi.setJndiResourceName(lookupName);
+            forJndi.setStatementFactory(new BasicStatementFactory());
+            forJndi.setStatementReuse(false);
+            TransactionManagerConnection connection = forJndi.getConnection(CONNECTION_NAME);
 
-        String sql = "SELECT * FROM TEST_TABLE";
-        SqlPStatement statement1 = connection.prepareStatement(sql);
-        SqlPStatement statement2 = connection.prepareStatement(sql);
-        assertThat("statementReuseの値をfalseに設定することでSqlPStatementが異なるものが返ってくる。",
-                statement1, not(is(statement2)));
-
+            String sql = "SELECT * FROM TEST_TABLE";
+            SqlPStatement statement1 = connection.prepareStatement(sql);
+            SqlPStatement statement2 = connection.prepareStatement(sql);
+            assertThat("statementReuseの値をfalseに設定することでSqlPStatementが異なるものが返ってくる。",
+                    statement1, not(is(statement2)));
+        }
     }
 
     /**
@@ -185,26 +168,25 @@ public class BasicDbConnectionFactoryForJndiTest {
     public void testGetConnectionError() throws Exception {
         // 想定する振る舞いを設定。
         final String lookupName = "test";
-        new Expectations() {{
-            jndiContext.lookup(lookupName);
-            result = new NamingException("リソースがない");
-        }};
+        try (final MockedConstruction<InitialContext> mocked = mockConstruction(InitialContext.class, (mock, context) -> {
+            when(mock.lookup(lookupName)).thenThrow(new NamingException("リソースがない"));
+        })) {
+            BasicDbConnectionFactoryForJndi forJndi = new BasicDbConnectionFactoryForJndi();
+            forJndi.setJndiResourceName(lookupName);
 
-        BasicDbConnectionFactoryForJndi forJndi = new BasicDbConnectionFactoryForJndi();
-        forJndi.setJndiResourceName(lookupName);
-        
-        Map<String, String> property = new HashMap<String, String>();
-        property.put(InitialContext.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.fscontext.RefFSContextFactory");
-        property.put(InitialContext.PROVIDER_URL, "file:./hoge/hoge");
-        forJndi.setJndiProperties(property);
+            Map<String, String> property = new HashMap<String, String>();
+            property.put(InitialContext.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.fscontext.RefFSContextFactory");
+            property.put(InitialContext.PROVIDER_URL, "file:./hoge/hoge");
+            forJndi.setJndiProperties(property);
 
-        try {
-            forJndi.getConnection(CONNECTION_NAME);
-            fail("例外が発生しないといけない.");
-        } catch (Exception e) {
-            assertThat(e.getMessage(), is("failed to DataSource lookup. jndiResourceName = [test]"));
-            assertThat(e.getCause(), not(nullValue()));
-            assertThat(e.getCause().getMessage(), is("リソースがない"));
+            try {
+                forJndi.getConnection(CONNECTION_NAME);
+                fail("例外が発生しないといけない.");
+            } catch (Exception e) {
+                assertThat(e.getMessage(), is("failed to DataSource lookup. jndiResourceName = [test]"));
+                assertThat(e.getCause(), not(nullValue()));
+                assertThat(e.getCause().getMessage(), is("リソースがない"));
+            }
         }
     }
 
@@ -227,26 +209,25 @@ public class BasicDbConnectionFactoryForJndiTest {
         final SQLException nativeException = new SQLException("connection取得時にエラー");
         final String message = "failed to get database connection. jndiResourceName = [test_error]";
         final DbConnectionException expected = new DbConnectionException(message, nativeException);
-        new Expectations() {{
-            jndiContext.lookup(lookupName);
-            result = dataSource;
-            dataSource.getConnection();
-            result = nativeException;
+
+        try (final MockedConstruction<InitialContext> mocked = mockConstruction(InitialContext.class, (mock, context) -> {
+            when(mock.lookup(lookupName)).thenReturn(dataSource);
+        })) {
+            when(dataSource.getConnection()).thenThrow(nativeException);
             // DataSourceが送出した例外を渡すことをverifyする。
-            exceptionFactory.createDbAccessException(message, nativeException, null);
-            result = expected;
-        }};
+            when(exceptionFactory.createDbAccessException(message, nativeException, null)).thenReturn(expected);
 
-        BasicDbConnectionFactoryForJndi forJndi = new BasicDbConnectionFactoryForJndi();
-        forJndi.setJndiResourceName(lookupName);
-        forJndi.setJndiProperties(property);
-        forJndi.setDbAccessExceptionFactory(exceptionFactory);
+            BasicDbConnectionFactoryForJndi forJndi = new BasicDbConnectionFactoryForJndi();
+            forJndi.setJndiResourceName(lookupName);
+            forJndi.setJndiProperties(property);
+            forJndi.setDbAccessExceptionFactory(exceptionFactory);
 
-        try {
-            forJndi.getConnection(CONNECTION_NAME);
-            fail("例外が発生しないといけない.");
-        } catch (DbConnectionException e) {
-            assertThat(e, is(expected));
+            try {
+                forJndi.getConnection(CONNECTION_NAME);
+                fail("例外が発生しないといけない.");
+            } catch (DbConnectionException e) {
+                assertThat(e, is(expected));
+            }
         }
     }
 
@@ -268,21 +249,21 @@ public class BasicDbConnectionFactoryForJndiTest {
         final String lookupName = "empty";
         final Properties jndiProp = new Properties();
         jndiProp.putAll(property);
-        new Expectations() {{
-            jndiContext.lookup(lookupName);
-            result = dataSource;
-            dataSource.getConnection();
-            result = null;
-        }};
-        BasicDbConnectionFactoryForJndi forJndi = new BasicDbConnectionFactoryForJndi();
-        forJndi.setJndiResourceName(lookupName);
-        forJndi.setJndiProperties(property);
+        
+        try (final MockedConstruction<InitialContext> mocked = mockConstruction(InitialContext.class, (mock, context) -> {
+            when(mock.lookup(lookupName)).thenReturn(dataSource);
+        })) {
+            when(dataSource.getConnection()).thenReturn(null);
+            BasicDbConnectionFactoryForJndi forJndi = new BasicDbConnectionFactoryForJndi();
+            forJndi.setJndiResourceName(lookupName);
+            forJndi.setJndiProperties(property);
 
-        try {
-            forJndi.getConnection(CONNECTION_NAME);
-            fail("例外が発生しないといけない.");
-        } catch (IllegalStateException e) {
-            assertThat(e.getMessage(), is("database connection lookup result was null. JNDI resource name = [empty]"));
+            try {
+                forJndi.getConnection(CONNECTION_NAME);
+                fail("例外が発生しないといけない.");
+            } catch (IllegalStateException e) {
+                assertThat(e.getMessage(), is("database connection lookup result was null. JNDI resource name = [empty]"));
+            }
         }
     }
 }

--- a/src/test/java/nablarch/core/db/connection/DbConnectionContextTest.java
+++ b/src/test/java/nablarch/core/db/connection/DbConnectionContextTest.java
@@ -1,18 +1,17 @@
 package nablarch.core.db.connection;
 
-import static org.hamcrest.CoreMatchers.*;
+import nablarch.core.transaction.TransactionContext;
+import org.junit.After;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-
-import nablarch.core.transaction.TransactionContext;
-
-import org.junit.After;
-import org.junit.Test;
-
-import mockit.Mocked;
+import static org.mockito.Mockito.mock;
 
 
 /**
@@ -22,11 +21,9 @@ import mockit.Mocked;
  */
 public class DbConnectionContextTest {
 
-    @Mocked
-    private AppDbConnection mockCon1;
+    private final AppDbConnection mockCon1 = mock(AppDbConnection.class);
 
-    @Mocked
-    private AppDbConnection mockCon2;
+    private final AppDbConnection mockCon2 = mock(AppDbConnection.class);
 
     @After
     public void cleanUpContext() {
@@ -136,7 +133,9 @@ public class DbConnectionContextTest {
                 .containConnection(TransactionContext.DEFAULT_TRANSACTION_CONTEXT_KEY));
     }
     @Test
-    public void testGetTransactionConnection(@Mocked TransactionManagerConnection tranConnection) {
+    public void testGetTransactionConnection() {
+        TransactionManagerConnection tranConnection = mock(TransactionManagerConnection.class);
+        
         /* デフォルトのConnectionName */
         DbConnectionContext.setConnection(tranConnection);
         assertThat("設定したTransactionManagerConnectionが取得できる。", DbConnectionContext.getTransactionManagerConnection(), sameInstance(tranConnection));

--- a/src/test/java/nablarch/core/db/statement/BasicSqlPStatementTestLogic.java
+++ b/src/test/java/nablarch/core/db/statement/BasicSqlPStatementTestLogic.java
@@ -1,9 +1,36 @@
 package nablarch.core.db.statement;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.Temporal;
+import jakarta.persistence.TemporalType;
+import jakarta.persistence.Transient;
+import nablarch.core.db.DbAccessException;
+import nablarch.core.db.DbExecutionContext;
+import nablarch.core.db.connection.BasicDbConnection;
+import nablarch.core.db.connection.ConnectionFactory;
+import nablarch.core.db.connection.TransactionManagerConnection;
+import nablarch.core.db.dialect.DefaultDialect;
+import nablarch.core.db.dialect.Dialect;
+import nablarch.core.db.statement.entity.ClobColumn;
+import nablarch.core.db.statement.entity.TextColumn;
+import nablarch.core.db.statement.exception.SqlStatementException;
+import nablarch.core.db.util.DbUtil;
+import nablarch.core.exception.IllegalOperationException;
+import nablarch.core.log.Logger;
+import nablarch.core.repository.ObjectLoader;
+import nablarch.core.repository.SystemRepository;
+import nablarch.core.transaction.TransactionContext;
+import nablarch.test.support.db.helper.TargetDb;
+import nablarch.test.support.db.helper.VariousDbTestHelper;
+import nablarch.test.support.log.app.OnMemoryLogWriter;
+import nablarch.test.support.reflection.ReflectionUtil;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -29,43 +56,33 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
-import jakarta.persistence.Temporal;
-import jakarta.persistence.TemporalType;
-import jakarta.persistence.Transient;
-
-import nablarch.core.db.DbAccessException;
-import nablarch.core.db.DbExecutionContext;
-import nablarch.core.db.connection.BasicDbConnection;
-import nablarch.core.db.connection.ConnectionFactory;
-import nablarch.core.db.connection.TransactionManagerConnection;
-import nablarch.core.db.dialect.DefaultDialect;
-import nablarch.core.db.dialect.Dialect;
-import nablarch.core.db.statement.entity.ClobColumn;
-import nablarch.core.db.statement.entity.TextColumn;
-import nablarch.core.db.statement.exception.SqlStatementException;
-import nablarch.core.db.util.DbUtil;
-import nablarch.core.exception.IllegalOperationException;
-import nablarch.core.log.Logger;
-import nablarch.core.repository.ObjectLoader;
-import nablarch.core.repository.SystemRepository;
-import nablarch.core.transaction.TransactionContext;
-import nablarch.test.support.db.helper.TargetDb;
-import nablarch.test.support.db.helper.VariousDbTestHelper;
-import nablarch.test.support.log.app.OnMemoryLogWriter;
-
-import org.junit.After;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
-import mockit.Deencapsulation;
-import mockit.Expectations;
-import mockit.Mocked;
-import mockit.Verifications;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyByte;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyFloat;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyShort;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.notNull;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * {@link BasicSqlPStatement}のテストクラス。
@@ -423,15 +440,12 @@ public abstract class BasicSqlPStatementTestLogic {
      * {@link BasicSqlPStatement#executeQuery()}でSQLExceptionが発生するケース。
      */
     @Test(expected = SqlStatementException.class)
-    public void executeQuery_SQLException(@Mocked final PreparedStatement mock) throws Exception {
-        new Expectations() {
-            {
-                mock.executeQuery();
-                result = new SQLException("executeQuery error.", "code", 100);
-            }
-        };
+    public void executeQuery_SQLException() throws Exception {
+        final PreparedStatement mock = mock(PreparedStatement.class);
+        
+        when(mock.executeQuery()).thenThrow(new SQLException("executeQuery error.", "code", 100));
         final SqlPStatement sut = dbCon.prepareStatement("SELECT * FROM STATEMENT_TEST_TABLE");
-        Deencapsulation.setField(sut, mock);
+        ReflectionUtil.setFieldValue(sut, "statement", mock);
         sut.executeQuery();
     }
 
@@ -439,14 +453,13 @@ public abstract class BasicSqlPStatementTestLogic {
      * {@link BasicSqlPStatement#executeUpdate()}のログ出力のテスト。
      */
     @Test
-    public void executeUpdate_writeSqlLog(@Mocked final PreparedStatement mockStatement) throws Exception {
-        new Expectations() {{
-            mockStatement.executeUpdate();
-            result = 5;
-        }};
+    public void executeUpdate_writeSqlLog() throws Exception {
+        final PreparedStatement mockStatement = mock(PreparedStatement.class);
+
+        when(mockStatement.executeUpdate()).thenReturn(5);
         final SqlPStatement sut = dbCon.prepareStatement(
                 "UPDATE STATEMENT_TEST_TABLE SET VARCHAR_COL = ? WHERE ENTITY_ID = ?");
-        Deencapsulation.setField(sut, mockStatement);
+        ReflectionUtil.setFieldValue(sut, "statement", mockStatement);
         sut.setString(1, "あいうえお\uD840\uDC0B");
         sut.setString(2, "10001");
         sut.executeUpdate();
@@ -518,15 +531,12 @@ public abstract class BasicSqlPStatementTestLogic {
      * {@link BasicSqlPStatement#executeUpdate()}でSQLExceptionが発生するケース。
      */
     @Test(expected = SqlStatementException.class)
-    public void executeUpdate_SQLException(@Mocked final PreparedStatement mock) throws Exception {
-        new Expectations() {
-            {
-                mock.executeUpdate();
-                result = new SQLException("executeUpdate error.", "code", 101);
-            }
-        };
+    public void executeUpdate_SQLException() throws Exception {
+        final PreparedStatement mock = mock(PreparedStatement.class);
+
+        when(mock.executeUpdate()).thenThrow(new SQLException("executeUpdate error.", "code", 101));
         final SqlPStatement sut = dbCon.prepareStatement("UPDATE STATEMENT_TEST_TABLE SET LONG_COL = 1");
-        Deencapsulation.setField(sut, mock);
+        ReflectionUtil.setFieldValue(sut, "statement", mock);
         sut.executeUpdate();
     }
 
@@ -597,14 +607,13 @@ public abstract class BasicSqlPStatementTestLogic {
      * DbAccessExceptionが送出されること。
      */
     @Test(expected = DbAccessException.class)
-    public void execute_SQLException(@Mocked final PreparedStatement mockStatement) throws Exception {
-        new Expectations() {{
-            mockStatement.execute();
-            result = new SQLException("execute error");
-        }};
+    public void execute_SQLException() throws Exception {
+        final PreparedStatement mockStatement = mock(PreparedStatement.class);
+
+        when(mockStatement.execute()).thenThrow(new SQLException("execute error"));
         final SqlPStatement sut = dbCon.prepareStatement(
                 "select * from STATEMENT_TEST_TABLE where ENTITY_ID = ?");
-        Deencapsulation.setField(sut, mockStatement);
+        ReflectionUtil.setFieldValue(sut, "statement", mockStatement);
         sut.setString(1, "10001");
         sut.execute();
     }
@@ -865,15 +874,14 @@ public abstract class BasicSqlPStatementTestLogic {
      * @throws Exception
      */
     @Test(expected = SqlStatementException.class)
-    public void retrieve_SQLException(@Mocked final PreparedStatement mockStatement) throws Exception {
-        new Expectations() {{
-            mockStatement.executeQuery();
-            result = new SQLException("retrieve error", "", 999);
-        }};
+    public void retrieve_SQLException() throws Exception {
+        final PreparedStatement mockStatement = mock(PreparedStatement.class);
+
+        when(mockStatement.executeQuery()).thenThrow(new SQLException("retrieve error", "", 999));
 
         final SqlPStatement sut = dbCon.prepareStatement(
                 "SELECT * FROM STATEMENT_TEST_TABLE");
-        Deencapsulation.setField(sut, mockStatement);
+        ReflectionUtil.setFieldValue(sut, "statement", mockStatement);
         sut.retrieve();
     }
 
@@ -884,17 +892,14 @@ public abstract class BasicSqlPStatementTestLogic {
      * @throws Exception
      */
     @Test(expected = IllegalStateException.class)
-    public void retrieve_RuntimeException(
-            @Mocked final PreparedStatement mockStatement) throws Exception {
-        new Expectations() {{
-            ResultSet rs = mockStatement.executeQuery();
-            rs.getMetaData();
-            result = new IllegalStateException("error");
-        }};
+    public void retrieve_RuntimeException() throws Exception {
+        final PreparedStatement mockStatement = mock(PreparedStatement.class, RETURNS_DEEP_STUBS);
+
+        when(mockStatement.executeQuery().getMetaData()).thenThrow(new IllegalStateException("error"));
 
         final SqlPStatement sut = dbCon.prepareStatement(
                 "SELECT * FROM STATEMENT_TEST_TABLE");
-        Deencapsulation.setField(sut, mockStatement);
+        ReflectionUtil.setFieldValue(sut, "statement", mockStatement);
         sut.retrieve();
     }
 
@@ -905,17 +910,14 @@ public abstract class BasicSqlPStatementTestLogic {
      * @throws Exception
      */
     @Test(expected = StackOverflowError.class)
-    public void retrieve_Error(
-            @Mocked final PreparedStatement mockStatement) throws Exception {
-        new Expectations() {{
-            ResultSet rs = mockStatement.executeQuery();
-            rs.getMetaData();
-            result = new StackOverflowError("error");
-        }};
+    public void retrieve_Error() throws Exception {
+        final PreparedStatement mockStatement = mock(PreparedStatement.class, RETURNS_DEEP_STUBS);
+
+        when(mockStatement.executeQuery().getMetaData()).thenThrow(new StackOverflowError("error"));
 
         final SqlPStatement sut = dbCon.prepareStatement(
                 "SELECT * FROM STATEMENT_TEST_TABLE");
-        Deencapsulation.setField(sut, mockStatement);
+        ReflectionUtil.setFieldValue(sut, "statement", mockStatement);
         sut.retrieve();
     }
 
@@ -926,21 +928,17 @@ public abstract class BasicSqlPStatementTestLogic {
      * @throws Exception
      */
     @Test
-    public void retrieve_finallyError(
-            @Mocked final PreparedStatement mockStatement) throws Exception {
+    public void retrieve_finallyError() throws Exception {
+        final PreparedStatement mockStatement = mock(PreparedStatement.class, RETURNS_DEEP_STUBS);
 
-        new Expectations() {{
-            ResultSet rs = mockStatement.executeQuery();
-            final ResultSetMetaData rsm = rs.getMetaData();
-            rsm.getColumnCount();
-            result = 0;
-            rs.close();
-            result = new NullPointerException("null");
-        }};
+        ResultSet rs = mockStatement.executeQuery();
+        ResultSetMetaData rsm = mockStatement.executeQuery().getMetaData();
+        when(rsm.getColumnCount()).thenReturn(0);
+        doThrow(new NullPointerException("null")).when(rs).close(); 
 
         final SqlPStatement sut = dbCon.prepareStatement(
                 "SELECT * FROM STATEMENT_TEST_TABLE");
-        Deencapsulation.setField(sut, mockStatement);
+        ReflectionUtil.setFieldValue(sut, "statement", mockStatement);
         try {
             sut.retrieve();
             fail("");
@@ -958,20 +956,17 @@ public abstract class BasicSqlPStatementTestLogic {
      * @throws Exception
      */
     @Test
-    public void retrieve_tryAndFinallyError(
-            @Mocked final PreparedStatement mockStatement) throws Exception {
+    public void retrieve_tryAndFinallyError() throws Exception {
+        final PreparedStatement mockStatement = mock(PreparedStatement.class, RETURNS_DEEP_STUBS);
 
-        new Expectations() {{
-            ResultSet rs = mockStatement.executeQuery();
-            rs.close();
-            result = new NullPointerException("null error");
-            rs.getMetaData();
-            result = new IllegalStateException("error");
-        }};
+        ResultSet rs = mockStatement.executeQuery();
 
+        doThrow(new NullPointerException("null error")).when(rs).close();
+        when(rs.getMetaData()).thenThrow(new IllegalStateException("error"));
+        
         final SqlPStatement sut = dbCon.prepareStatement(
                 "SELECT * FROM STATEMENT_TEST_TABLE");
-        Deencapsulation.setField(sut, mockStatement);
+        ReflectionUtil.setFieldValue(sut, "statement", mockStatement);
         try {
             sut.retrieve();
             fail("");
@@ -1010,15 +1005,14 @@ public abstract class BasicSqlPStatementTestLogic {
      * @throws Exception
      */
     @Test(expected = DbAccessException.class)
-    public void addBatch_SQLException(@Mocked final PreparedStatement mockStatement) throws Exception {
-        new Expectations() {{
-            mockStatement.addBatch();
-            result = new SQLException("addBatch error", "", 999);
-        }};
+    public void addBatch_SQLException() throws Exception {
+        final PreparedStatement mockStatement = mock(PreparedStatement.class);
+
+        doThrow(new SQLException("addBatch error", "", 999)).when(mockStatement).addBatch();
 
         final SqlPStatement sut = dbCon.prepareStatement(
                 "INSERT INTO STATEMENT_TEST_TABLE (ENTITY_ID) VALUES (?)");
-        Deencapsulation.setField(sut, mockStatement);
+        ReflectionUtil.setFieldValue(sut, "statement", mockStatement);
         sut.setString(1, "1");
         sut.addBatch();
     }
@@ -1082,18 +1076,16 @@ public abstract class BasicSqlPStatementTestLogic {
      * SqlStatementExceptionが送出されること。
      */
     @Test(expected = SqlStatementException.class)
-    public void executeBatch_SQLException(
-            @Mocked final PreparedStatement mockStatement) throws Exception {
-        new Expectations() {{
-            mockStatement.executeBatch();
-            result = new SQLException("executeBatch error", "", 999);
-        }};
+    public void executeBatch_SQLException() throws Exception {
+        final PreparedStatement mockStatement = mock(PreparedStatement.class);
+
+        when(mockStatement.executeBatch()).thenThrow(new SQLException("executeBatch error", "", 999));
 
         final SqlPStatement sut = dbCon.prepareStatement(
                 "INSERT INTO STATEMENT_TEST_TABLE (ENTITY_ID) VALUES (?)");
         sut.setString(1, "99999");
         sut.addBatch();
-        Deencapsulation.setField(sut, mockStatement);
+        ReflectionUtil.setFieldValue(sut, "statement", mockStatement);
         sut.executeBatch();
     }
 
@@ -1147,16 +1139,14 @@ public abstract class BasicSqlPStatementTestLogic {
      * DbAccessExceptionが送出されること。
      */
     @Test(expected = DbAccessException.class)
-    public void clearBatch_SQLException(
-            @Mocked final PreparedStatement mockStatement) throws Exception {
-        new Expectations() {{
-            mockStatement.clearBatch();
-            result = new SQLException("clear batch error");
-        }};
+    public void clearBatch_SQLException() throws Exception {
+        final PreparedStatement mockStatement = mock(PreparedStatement.class);
+
+        doThrow(new SQLException("clear batch error")).when(mockStatement).clearBatch();
 
         final SqlPStatement sut = dbCon.prepareStatement(
                 "INSERT INTO STATEMENT_TEST_TABLE (ENTITY_ID) VALUES (?)");
-        Deencapsulation.setField(sut, mockStatement);
+        ReflectionUtil.setFieldValue(sut, "statement", mockStatement);
         sut.clearBatch();
     }
 
@@ -1216,17 +1206,16 @@ public abstract class BasicSqlPStatementTestLogic {
      * DbAccessExceptionが送出されること。
      */
     @Test(expected = DbAccessException.class)
-    public void setNull_SQLException(@Mocked final PreparedStatement mockStatement) throws Exception {
-        new Expectations() {{
-            mockStatement.setNull(anyInt, anyInt);
-            result = new SQLException("setNull error");
-        }};
+    public void setNull_SQLException() throws Exception {
+        final PreparedStatement mockStatement = mock(PreparedStatement.class);
+
+        doThrow(new SQLException("setNull error")).when(mockStatement).setNull(anyInt(), anyInt());
 
         final SqlPStatement sut = dbCon.prepareStatement(
                 "INSERT INTO STATEMENT_TEST_TABLE (ENTITY_ID, VARCHAR_COL) "
                         + "VALUES (?, ?)");
 
-        Deencapsulation.setField(sut, mockStatement);
+        ReflectionUtil.setFieldValue(sut, "statement", mockStatement);
         sut.setString(1, "99999");
         sut.setNull(2, Types.VARCHAR);
     }
@@ -1273,14 +1262,13 @@ public abstract class BasicSqlPStatementTestLogic {
      * DbAccessExceptionが送出されること。
      */
     @Test(expected = DbAccessException.class)
-    public void setBoolean_SQLException(@Mocked final PreparedStatement mockStatement) throws Exception {
-        new Expectations() {{
-            mockStatement.setBoolean(anyInt, anyBoolean);
-            result = new SQLException("setBoolean error");
-        }};
+    public void setBoolean_SQLException() throws Exception {
+        final PreparedStatement mockStatement = mock(PreparedStatement.class);
+
+        doThrow(new SQLException("setBoolean error")).when(mockStatement).setBoolean(anyInt(), anyBoolean());
         final SqlPStatement sut = dbCon.prepareStatement(
                 "UPDATE STATEMENT_TEST_TABLE SET VARCHAR_COL = ?, LONG_COL = ?");
-        Deencapsulation.setField(sut, mockStatement);
+        ReflectionUtil.setFieldValue(sut, "statement", mockStatement);
         sut.setBoolean(2, false);
     }
 
@@ -1329,14 +1317,13 @@ public abstract class BasicSqlPStatementTestLogic {
      * DbAccessExceptionが送出されること。
      */
     @Test(expected = DbAccessException.class)
-    public void setByte_SQLException(@Mocked final PreparedStatement mockStatement) throws Exception {
-        new Expectations() {{
-            mockStatement.setByte(anyInt, anyByte);
-            result = new SQLException("setByte error.");
-        }};
+    public void setByte_SQLException() throws Exception {
+        final PreparedStatement mockStatement = mock(PreparedStatement.class);
+
+        doThrow(new SQLException("setByte error.")).when(mockStatement).setByte(anyInt(), anyByte());
         final SqlPStatement sut = dbCon.prepareStatement(
                 "SELECT '1' FROM STATEMENT_TEST_TABLE WHERE ENTITY_ID = ?");
-        Deencapsulation.setField(sut, mockStatement);
+        ReflectionUtil.setFieldValue(sut, "statement", mockStatement);
         sut.setByte(1, (byte) 0x00);
     }
 
@@ -1373,13 +1360,12 @@ public abstract class BasicSqlPStatementTestLogic {
      * DbAccessExceptionが送出されること。
      */
     @Test(expected = DbAccessException.class)
-    public void setShort_SQLException(@Mocked final PreparedStatement mockStatement) throws Exception {
-        new Expectations() {{
-            mockStatement.setShort(anyInt, anyShort);
-            result = new SQLException("setShort error");
-        }};
+    public void setShort_SQLException() throws Exception {
+        final PreparedStatement mockStatement = mock(PreparedStatement.class);
+
+        doThrow(new SQLException("setShort error")).when(mockStatement).setShort(anyInt(), anyShort());
         final SqlPStatement sut = dbCon.prepareStatement("SELECT * FROM STATEMENT_TEST_TABLE WHERE LONG_COL = ?");
-        Deencapsulation.setField(sut, mockStatement);
+        ReflectionUtil.setFieldValue(sut, "statement", mockStatement);
         sut.setShort(1, (short) 1);
     }
 
@@ -1418,14 +1404,13 @@ public abstract class BasicSqlPStatementTestLogic {
      * DbAccessExceptionが送出されること
      */
     @Test(expected = DbAccessException.class)
-    public void setInt_SQLException(@Mocked final PreparedStatement mockStatement) throws Exception {
-        new Expectations() {{
-            mockStatement.setInt(anyInt, anyInt);
-            result = new SQLException("setInt error");
-        }};
+    public void setInt_SQLException() throws Exception {
+        final PreparedStatement mockStatement = mock(PreparedStatement.class);
+
+        doThrow(new SQLException("setInt error")).when(mockStatement).setInt(anyInt(), anyInt());
         final SqlPStatement sut = dbCon.prepareStatement(
                 "SELECT * FROM STATEMENT_TEST_TABLE WHERE INTEGER_COL IN (?, ?)");
-        Deencapsulation.setField(sut, mockStatement);
+        ReflectionUtil.setFieldValue(sut, "statement", mockStatement);
         sut.setInt(1, 2);
     }
 
@@ -1464,14 +1449,13 @@ public abstract class BasicSqlPStatementTestLogic {
      * DbAccessExceptionが送出されること
      */
     @Test(expected = DbAccessException.class)
-    public void setLong_SQLException(@Mocked final PreparedStatement mockStatement) throws Exception {
-        new Expectations() {{
-            mockStatement.setLong(anyInt, anyLong);
-            result = new SQLException("setLong error");
-        }};
+    public void setLong_SQLException() throws Exception {
+        final PreparedStatement mockStatement = mock(PreparedStatement.class);
+
+        doThrow(new SQLException("setLong error")).when(mockStatement).setLong(anyInt(), anyLong());
         final SqlPStatement sut = dbCon.prepareStatement(
                 "SELECT * FROM STATEMENT_TEST_TABLE WHERE INTEGER_COL IN (?, ?)");
-        Deencapsulation.setField(sut, mockStatement);
+        ReflectionUtil.setFieldValue(sut, "statement", mockStatement);
         sut.setLong(1, 2);
     }
 
@@ -1511,14 +1495,13 @@ public abstract class BasicSqlPStatementTestLogic {
      * DbAccessExceptionが送出されること
      */
     @Test(expected = DbAccessException.class)
-    public void setFloat_SQLException(@Mocked final PreparedStatement mockStatement) throws Exception {
-        new Expectations() {{
-            mockStatement.setFloat(anyInt, anyFloat);
-            result = new SQLException("setFloat error");
-        }};
+    public void setFloat_SQLException() throws Exception {
+        final PreparedStatement mockStatement = mock(PreparedStatement.class);
+
+        doThrow(new SQLException("setFloat error")).when(mockStatement).setFloat(anyInt(), anyFloat());
         final SqlPStatement sut = dbCon.prepareStatement(
                 "SELECT * FROM STATEMENT_TEST_TABLE WHERE INTEGER_COL IN (?, ?)");
-        Deencapsulation.setField(sut, mockStatement);
+        ReflectionUtil.setFieldValue(sut, "statement", mockStatement);
         sut.setFloat(1, 2.2f);
     }
 
@@ -1559,14 +1542,13 @@ public abstract class BasicSqlPStatementTestLogic {
      * DbAccessExceptionが送出されること
      */
     @Test(expected = DbAccessException.class)
-    public void setDouble_SQLException(@Mocked final PreparedStatement mockStatement) throws Exception {
-        new Expectations() {{
-            mockStatement.setDouble(anyInt, anyDouble);
-            result = new SQLException("setDouble error");
-        }};
+    public void setDouble_SQLException() throws Exception {
+        final PreparedStatement mockStatement = mock(PreparedStatement.class);
+
+        doThrow(new SQLException("setDouble error")).when(mockStatement).setDouble(anyInt(), anyDouble());
         final SqlPStatement sut = dbCon.prepareStatement(
                 "SELECT * FROM STATEMENT_TEST_TABLE WHERE INTEGER_COL IN (?, ?)");
-        Deencapsulation.setField(sut, mockStatement);
+        ReflectionUtil.setFieldValue(sut, "statement", mockStatement);
         sut.setDouble(1, 2.2);
     }
 
@@ -1606,13 +1588,12 @@ public abstract class BasicSqlPStatementTestLogic {
      * DbAccessExceptionが送出されること
      */
     @Test(expected = DbAccessException.class)
-    public void setBigDecimal_SQLException(@Mocked final PreparedStatement mockStatement) throws Exception {
-        new Expectations() {{
-            mockStatement.setBigDecimal(anyInt, BigDecimal.ONE);
-            result = new SQLException("setBigDecimal error");
-        }};
+    public void setBigDecimal_SQLException() throws Exception {
+        final PreparedStatement mockStatement = mock(PreparedStatement.class);
+
+        doThrow(new SQLException("setBigDecimal error")).when(mockStatement).setBigDecimal(anyInt(), eq(BigDecimal.ONE));
         final SqlPStatement sut = dbCon.prepareStatement("SELECT * FROM STATEMENT_TEST_TABLE WHERE ENTITY_ID = ?");
-        Deencapsulation.setField(sut, mockStatement);
+        ReflectionUtil.setFieldValue(sut, "statement", mockStatement);
         sut.setBigDecimal(1, BigDecimal.ONE);
     }
 
@@ -1655,13 +1636,12 @@ public abstract class BasicSqlPStatementTestLogic {
      * DbAccessExceptionが送出されること
      */
     @Test(expected = DbAccessException.class)
-    public void setString_SQLException(@Mocked final PreparedStatement mockStatement) throws Exception {
-        new Expectations() {{
-            mockStatement.setString(anyInt, anyString);
-            result = new SQLException("setString error");
-        }};
+    public void setString_SQLException() throws Exception {
+        final PreparedStatement mockStatement = mock(PreparedStatement.class);
+
+        doThrow(new SQLException("setString error")).when(mockStatement).setString(anyInt(), anyString());
         final SqlPStatement sut = dbCon.prepareStatement("SELECT * FROM STATEMENT_TEST_TABLE WHERE ENTITY_ID = ?");
-        Deencapsulation.setField(sut, mockStatement);
+        ReflectionUtil.setFieldValue(sut, "statement", mockStatement);
         sut.setString(1, "1");
     }
 
@@ -1706,15 +1686,14 @@ public abstract class BasicSqlPStatementTestLogic {
      * DbAccessExceptionが送出されること
      */
     @Test(expected = DbAccessException.class)
-    public void setBytes_SQLException(@Mocked final PreparedStatement mockStatement) throws Exception {
-        new Expectations() {{
-            mockStatement.setBytes(anyInt, (byte[]) withNotNull());
-            result = new SQLException("setBytes error");
-        }};
+    public void setBytes_SQLException() throws Exception {
+        final PreparedStatement mockStatement = mock(PreparedStatement.class);
 
+        doThrow(new SQLException("setBytes error")).when(mockStatement).setBytes(anyInt(), notNull());
+        
         final SqlPStatement sut = dbCon.prepareStatement(
                 "INSERT INTO STATEMENT_TEST_TABLE (ENTITY_ID, BINARY_COL) VALUES (?, ?)");
-        Deencapsulation.setField(sut, mockStatement);
+        ReflectionUtil.setFieldValue(sut, "statement", mockStatement);
         sut.setBytes(2, new byte[] {0x00, 0x01});
     }
 
@@ -1771,16 +1750,15 @@ public abstract class BasicSqlPStatementTestLogic {
      * DbAccessExceptionが送出されること
      */
     @Test(expected = DbAccessException.class)
-    public void setDate_SQLException(@Mocked final PreparedStatement mockStatement) throws Exception {
-        new Expectations(){{
-            mockStatement.setDate(anyInt, withAny(new java.sql.Date(0)));
-            result = new SQLException("setDate error");
-        }};
+    public void setDate_SQLException() throws Exception {
+        final PreparedStatement mockStatement = mock(PreparedStatement.class);
+
+        doThrow(new SQLException("setDate error")).when(mockStatement).setDate(anyInt(), any(java.sql.Date.class));
 
         final SqlPStatement sut = dbCon.prepareStatement(
                 "INSERT INTO STATEMENT_TEST_TABLE (ENTITY_ID, DATE_COL) VALUES  (?, ?)");
 
-        Deencapsulation.setField(sut, mockStatement);
+        ReflectionUtil.setFieldValue(sut, "statement", mockStatement);
         sut.setDate(2, new java.sql.Date(0));
     }
 
@@ -1835,16 +1813,15 @@ public abstract class BasicSqlPStatementTestLogic {
      * DbAccessExceptionが送出されること
      */
     @Test(expected = DbAccessException.class)
-    public void setTime_SQLException(@Mocked final PreparedStatement mockStatement) throws Exception {
-        new Expectations(){{
-            mockStatement.setTime(anyInt, withAny(new Time(0)));
-            result = new SQLException("setTime error");
-        }};
+    public void setTime_SQLException() throws Exception {
+        final PreparedStatement mockStatement = mock(PreparedStatement.class);
+
+        doThrow(new SQLException("setTime error")).when(mockStatement).setTime(anyInt(), any(Time.class));
 
         final SqlPStatement sut = dbCon.prepareStatement(
                 "INSERT INTO STATEMENT_TEST_TABLE (ENTITY_ID, TIME_COL) VALUES  (?, ?)");
 
-        Deencapsulation.setField(sut, mockStatement);
+        ReflectionUtil.setFieldValue(sut, "statement", mockStatement);
         sut.setTime(2, new Time(0));
     }
 
@@ -1896,16 +1873,15 @@ public abstract class BasicSqlPStatementTestLogic {
      * DbAccessExceptionが送出されること。
      */
     @Test(expected = DbAccessException.class)
-    public void setTimestamp_SQLException(@Mocked final PreparedStatement mockStatement) throws Exception {
-        new Expectations(){{
-            mockStatement.setTimestamp(anyInt, withAny(new Timestamp(0)));
-            result = new SQLException("setTimestamp error");
-        }};
+    public void setTimestamp_SQLException() throws Exception {
+        final PreparedStatement mockStatement = mock(PreparedStatement.class);
+
+        doThrow(new SQLException("setTimestamp error")).when(mockStatement).setTimestamp(anyInt(), any(Timestamp.class));
 
         final SqlPStatement sut = dbCon.prepareStatement(
                 "INSERT INTO STATEMENT_TEST_TABLE (ENTITY_ID, TIMESTAMP_COL) VALUES  (?, ?)");
 
-        Deencapsulation.setField(sut, mockStatement);
+        ReflectionUtil.setFieldValue(sut, "statement", mockStatement);
         sut.setTimestamp(2, new Timestamp(0));
     }
 
@@ -1979,15 +1955,14 @@ public abstract class BasicSqlPStatementTestLogic {
      * DbAccessExceptionが送出されること。
      */
     @Test(expected = DbAccessException.class)
-    public void setAsciiStream_SQLException(@Mocked final PreparedStatement mockStatement) throws Exception {
-        new Expectations(){{
-            mockStatement.setAsciiStream(anyInt, withAny(new ByteArrayInputStream(new byte[0])), anyInt);
-            result = new SQLException("setAsciiStream error");
-        }};
+    public void setAsciiStream_SQLException() throws Exception {
+        final PreparedStatement mockStatement = mock(PreparedStatement.class);
+
+        doThrow(new SQLException("setAsciiStream error")).when(mockStatement).setAsciiStream(anyInt(), any(ByteArrayInputStream.class), anyInt());
 
         final SqlPStatement sut = dbCon.prepareStatement(
                 "INSERT INTO STATEMENT_TEST_TABLE (ENTITY_ID, VARCHAR_COL) VALUES  (?, ?)");
-        Deencapsulation.setField(sut, mockStatement);
+        ReflectionUtil.setFieldValue(sut, "statement", mockStatement);
         sut.setAsciiStream(2, new ByteArrayInputStream(new byte[0]), 0);
     }
 
@@ -2041,13 +2016,13 @@ public abstract class BasicSqlPStatementTestLogic {
      * DbAccessExceptionが送出される。
      */
     @Test(expected = DbAccessException.class)
-    public void setObject_SQLException(@Mocked final PreparedStatement mockStatement) throws Exception {
-        new Expectations() {{
-            mockStatement.setObject(anyInt, any);
-            result = new SQLException("setObject error");
-        }};
+    public void setObject_SQLException() throws Exception {
+        final PreparedStatement mockStatement = mock(PreparedStatement.class);
+
+        doThrow(new SQLException("setObject error")).when(mockStatement).setObject(anyInt(), any());
+        
         final SqlPStatement sut = dbCon.prepareStatement("SELECT * FROM STATEMENT_TEST_TABLE WHERE ENTITY_ID = ?");
-        Deencapsulation.setField(sut, mockStatement);
+        ReflectionUtil.setFieldValue(sut, "statement", mockStatement);
         sut.setObject(1, "12345");
     }
 
@@ -2101,13 +2076,13 @@ public abstract class BasicSqlPStatementTestLogic {
      * DbAccessExceptionが送出される。
      */
     @Test(expected = DbAccessException.class)
-    public void setObjectWithType_SQLException(@Mocked final PreparedStatement mockStatement) throws Exception {
-        new Expectations() {{
-            mockStatement.setObject(anyInt, any, anyInt);
-            result = new SQLException("setObjectWithType error");
-        }};
+    public void setObjectWithType_SQLException() throws Exception {
+        final PreparedStatement mockStatement = mock(PreparedStatement.class);
+
+        doThrow(new SQLException("setObjectWithType error")).when(mockStatement).setObject(anyInt(), any(), anyInt());
+        
         final SqlPStatement sut = dbCon.prepareStatement("SELECT * FROM STATEMENT_TEST_TABLE WHERE ENTITY_ID = ?");
-        Deencapsulation.setField(sut, mockStatement);
+        ReflectionUtil.setFieldValue(sut, "statement", mockStatement);
         sut.setObject(1, "12345", Types.CHAR);
     }
 
@@ -2136,13 +2111,12 @@ public abstract class BasicSqlPStatementTestLogic {
      * DbAccessExceptionが送出されること。
      */
     @Test(expected = DbAccessException.class)
-    public void getResultSet_SQLException(@Mocked final PreparedStatement mockStatement) throws Exception {
-        new Expectations() {{
-            mockStatement.getResultSet();
-            result = new SQLException("getResultSet error");
-        }};
+    public void getResultSet_SQLException() throws Exception {
+        final PreparedStatement mockStatement = mock(PreparedStatement.class);
+
+        doThrow(new SQLException("getResultSet error")).when(mockStatement).getResultSet();
         final SqlPStatement sut = dbCon.prepareStatement("SELECT * FROM STATEMENT_TEST_TABLE");
-        Deencapsulation.setField(sut, mockStatement);
+        ReflectionUtil.setFieldValue(sut, "statement", mockStatement);
         sut.getResultSet();
     }
 
@@ -2188,13 +2162,13 @@ public abstract class BasicSqlPStatementTestLogic {
      * DbAccessExceptionが送出されること。
      */
     @Test(expected = DbAccessException.class)
-    public void getUpdateCount_SQLException(@Mocked final PreparedStatement mockStatement) throws Exception {
-        new Expectations() {{
-            mockStatement.getUpdateCount();
-            result = new SQLException("getUpdateCount error");
-        }};
+    public void getUpdateCount_SQLException() throws Exception {
+        final PreparedStatement mockStatement = mock(PreparedStatement.class);
+
+        when(mockStatement.getUpdateCount()).thenThrow(new SQLException("getUpdateCount error"));
+        
         final SqlPStatement sut = dbCon.prepareStatement("UPDATE STATEMENT_TEST_TABLE SET ENTITY_ID = ENTITY_ID");
-        Deencapsulation.setField(sut, mockStatement);
+        ReflectionUtil.setFieldValue(sut, "statement", mockStatement);
         sut.getUpdateCount();
     }
 
@@ -2213,14 +2187,13 @@ public abstract class BasicSqlPStatementTestLogic {
      * DbAccessExceptionが送出されること。
      */
     @Test(expected = DbAccessException.class)
-    public void getMetaData_SQLException(@Mocked final PreparedStatement mockStatement) throws Exception {
-        new Expectations() {{
-            mockStatement.getMetaData();
-            result = new SQLException("getMetaData error");
-        }};
+    public void getMetaData_SQLException() throws Exception {
+        final PreparedStatement mockStatement = mock(PreparedStatement.class);
+
+        when(mockStatement.getMetaData()).thenThrow(new SQLException("getMetaData error"));
         SqlPStatement sut = dbCon.prepareStatement(
                 "SELECT ENTITY_ID, LONG_COL from STATEMENT_TEST_TABLE where ENTITY_ID = ?");
-        Deencapsulation.setField(sut, mockStatement);
+        ReflectionUtil.setFieldValue(sut, "statement", mockStatement);
         sut.getMetaData();
     }
 
@@ -2262,14 +2235,13 @@ public abstract class BasicSqlPStatementTestLogic {
      * DbAccessExceptionが送出されること。
      */
     @Test(expected = DbAccessException.class)
-    public void setMaxRows_SQLException(@Mocked final PreparedStatement mockStatement) throws Exception {
-        new Expectations() {{
-            mockStatement.setMaxRows(anyInt);
-            result = new SQLException("setMaxRows error");
-        }};
+    public void setMaxRows_SQLException() throws Exception {
+        final PreparedStatement mockStatement = mock(PreparedStatement.class);
+
+        doThrow(new SQLException("setMaxRows error")).when(mockStatement).setMaxRows(anyInt());
 
         final SqlPStatement sut = dbCon.prepareStatement("SELECT * FROM STATEMENT_TEST_TABLE");
-        Deencapsulation.setField(sut, mockStatement);
+        ReflectionUtil.setFieldValue(sut, "statement", mockStatement);
         sut.setMaxRows(2);
     }
 
@@ -2278,13 +2250,12 @@ public abstract class BasicSqlPStatementTestLogic {
      * DbAccessExceptionが送出されること。
      */
     @Test(expected = DbAccessException.class)
-    public void getMaxRows_SQLException(@Mocked final PreparedStatement mockStatement) throws Exception {
-        new Expectations() {{
-            mockStatement.getMaxRows();
-            result = new SQLException("getMaxRows error");
-        }};
+    public void getMaxRows_SQLException() throws Exception {
+        final PreparedStatement mockStatement = mock(PreparedStatement.class);
+
+        when(mockStatement.getMaxRows()).thenThrow(new SQLException("getMaxRows error"));
         final SqlPStatement sut = dbCon.prepareStatement("SELECT * FROM STATEMENT_TEST_TABLE");
-        Deencapsulation.setField(sut, mockStatement);
+        ReflectionUtil.setFieldValue(sut, "statement", mockStatement);
         sut.getMaxRows();
     }
 
@@ -2316,14 +2287,13 @@ public abstract class BasicSqlPStatementTestLogic {
      * DbAccessExceptionが送出されること。
      */
     @Test(expected = DbAccessException.class)
-    public void setFetchSize_SQLException(@Mocked final PreparedStatement mockStatement) throws Exception {
-        new Expectations() {{
-            mockStatement.setFetchSize(anyInt);
-            result = new SQLException("setFetchSize error");
-        }};
+    public void setFetchSize_SQLException() throws Exception {
+        final PreparedStatement mockStatement = mock(PreparedStatement.class);
+
+        doThrow(new SQLException("setFetchSize error")).when(mockStatement).setFetchSize(anyInt());
 
         final SqlPStatement sut = dbCon.prepareStatement("SELECT * FROM STATEMENT_TEST_TABLE");
-        Deencapsulation.setField(sut, mockStatement);
+        ReflectionUtil.setFieldValue(sut, "statement", mockStatement);
         sut.setFetchSize(10);
     }
 
@@ -2332,14 +2302,13 @@ public abstract class BasicSqlPStatementTestLogic {
      * DbAccessExceptionが送出されること。
      */
     @Test(expected = DbAccessException.class)
-    public void getFetchSize_SQLException(@Mocked final PreparedStatement mockStatement) throws Exception {
-        new Expectations() {{
-            mockStatement.getFetchSize();
-            result = new SQLException("getFetchSize error");
-        }};
+    public void getFetchSize_SQLException() throws Exception {
+        final PreparedStatement mockStatement = mock(PreparedStatement.class);
+
+        when(mockStatement.getFetchSize()).thenThrow(new SQLException("getFetchSize error"));
 
         final SqlPStatement sut = dbCon.prepareStatement("SELECT * FROM STATEMENT_TEST_TABLE");
-        Deencapsulation.setField(sut, mockStatement);
+        ReflectionUtil.setFieldValue(sut, "statement", mockStatement);
         sut.setFetchSize(10);
         sut.getFetchSize();
     }
@@ -2370,14 +2339,13 @@ public abstract class BasicSqlPStatementTestLogic {
      * DbAccessExceptionが送出されること。
      */
     @Test(expected = DbAccessException.class)
-    public void setQueryTimeout_SQLException(@Mocked final PreparedStatement mockStatement) throws Exception {
-        new Expectations() {{
-            mockStatement.setQueryTimeout(anyInt);
-            result = new SQLException("setQueryTimeout error");
-        }};
+    public void setQueryTimeout_SQLException() throws Exception {
+        final PreparedStatement mockStatement = mock(PreparedStatement.class);
+
+        doThrow(new SQLException("setQueryTimeout error")).when(mockStatement).setQueryTimeout(anyInt());
 
         final SqlPStatement sut = dbCon.prepareStatement("SELECT * FROM STATEMENT_TEST_TABLE");
-        Deencapsulation.setField(sut, mockStatement);
+        ReflectionUtil.setFieldValue(sut, "statement", mockStatement);
         sut.setQueryTimeout(10);
     }
 
@@ -2386,14 +2354,13 @@ public abstract class BasicSqlPStatementTestLogic {
      * DbAccessExceptionが送出されること。
      */
     @Test(expected = DbAccessException.class)
-    public void getQueryTimeout_SQLException(@Mocked final PreparedStatement mockStatement) throws Exception {
-        new Expectations() {{
-            mockStatement.getQueryTimeout();
-            result = new SQLException("getQueryTimeout error");
-        }};
+    public void getQueryTimeout_SQLException() throws Exception {
+        final PreparedStatement mockStatement = mock(PreparedStatement.class);
+
+        when(mockStatement.getQueryTimeout()).thenThrow(new SQLException("getQueryTimeout error"));
 
         final SqlPStatement sut = dbCon.prepareStatement("SELECT * FROM STATEMENT_TEST_TABLE");
-        Deencapsulation.setField(sut, mockStatement);
+        ReflectionUtil.setFieldValue(sut, "statement", mockStatement);
         sut.getQueryTimeout();
     }
 
@@ -2440,15 +2407,15 @@ public abstract class BasicSqlPStatementTestLogic {
      * DbAccessExceptionが発生する。
      */
     @Test(expected = DbAccessException.class)
-    public void setBinaryStream_SQLException(@Mocked final PreparedStatement mockStatement) throws Exception {
-        new Expectations() {{
-            mockStatement.setBinaryStream(anyInt, withAny(new ByteArrayInputStream(new byte[0])), anyInt);
-            result = new SQLException("setBinaryStream error");
-        }};
+    public void setBinaryStream_SQLException() throws Exception {
+        final PreparedStatement mockStatement = mock(PreparedStatement.class);
+
+        doThrow(new SQLException("setBinaryStream error")).when(mockStatement).setBinaryStream(anyInt(), any(ByteArrayInputStream.class), anyInt());
+        
         final SqlPStatement sut = dbCon.prepareStatement(
                 "INSERT INTO STATEMENT_TEST_TABLE (ENTITY_ID, BINARY_COL) VALUES (?, ?)");
 
-        Deencapsulation.setField(sut, mockStatement);
+        ReflectionUtil.setFieldValue(sut, "statement", mockStatement);
         sut.setBinaryStream(2, new ByteArrayInputStream(new byte[] {0x31, 0x32, 0x33}), 2);
     }
 
@@ -2473,15 +2440,14 @@ public abstract class BasicSqlPStatementTestLogic {
      * {@link BasicSqlPStatement#setCharacterStream(int, Reader, int)}のテスト。
      */
     @Test(expected = DbAccessException.class)
-    public void setCharacterStream_SQLException(@Mocked final PreparedStatement mockStatement) throws Exception {
-        new Expectations() {{
-            mockStatement.setCharacterStream(anyInt, (Reader) any, anyInt);
-            result = new SQLException("setCharacterStream error");
-        }};
+    public void setCharacterStream_SQLException() throws Exception {
+        final PreparedStatement mockStatement = mock(PreparedStatement.class);
+
+        doThrow(new SQLException("setCharacterStream error")).when(mockStatement).setCharacterStream(anyInt(), any(Reader.class), anyInt());
         
         final SqlPStatement sut = dbCon.prepareStatement(
                 "insert into STATEMENT_TEST_TABLE (entity_id, varchar_col) values (?, ?)");
-        Deencapsulation.setField(sut, mockStatement);
+        ReflectionUtil.setFieldValue(sut, "statement", mockStatement);
         sut.setCharacterStream(2, new StringReader("1234554321"), 10);
     }
 
@@ -2490,7 +2456,7 @@ public abstract class BasicSqlPStatementTestLogic {
      */
     @Test
     public void close() {
-        final List<SqlStatement> statements = Deencapsulation.getField(dbCon, "statements");
+        final List<SqlStatement> statements = ReflectionUtil.getFieldValue(dbCon, "statements");
         assertThat("ステートメントリストは空であること", statements.isEmpty(), is(true));
 
         final SqlPStatement sut = dbCon.prepareStatement("select * from STATEMENT_TEST_TABLE");
@@ -2515,14 +2481,18 @@ public abstract class BasicSqlPStatementTestLogic {
      * DbAccessExceptionが送出されること。
      */
     @Test(expected = DbAccessException.class)
-    public void close_SQLException(@Mocked final PreparedStatement mockStatement) throws Exception {
-        new Expectations() {{
-            mockStatement.close();
-            result = new SQLException("close error");
-        }};
+    public void close_SQLException() throws Exception {
+        final PreparedStatement mockStatement = mock(PreparedStatement.class);
+
+        doThrow(new SQLException("close error")).when(mockStatement).close();
         final SqlPStatement sut = dbCon.prepareStatement("select * from STATEMENT_TEST_TABLE");
-        Deencapsulation.setField(sut, mockStatement);
-        sut.close();
+        ReflectionUtil.setFieldValue(sut, "statement", mockStatement);
+        try {
+            sut.close();
+        } finally {
+            // @After で dbCon が close されるときにモックが例外をスローしたままだとテストが落ちるのでリセットしておく
+            reset(mockStatement);
+        }
     }
 
     /**
@@ -2531,13 +2501,12 @@ public abstract class BasicSqlPStatementTestLogic {
      * Mockを使ってテストを行う。
      */
     @Test
-    public void getMoreResults(@Mocked final PreparedStatement mockStatement) throws Exception {
-        new Expectations() {{
-            mockStatement.getMoreResults();
-            returns(true, false);
-        }};
+    public void getMoreResults() throws Exception {
+        final PreparedStatement mockStatement = mock(PreparedStatement.class);
+
+        when(mockStatement.getMoreResults()).thenReturn(true, false);
         final SqlPStatement sut = dbCon.prepareStatement("select * from STATEMENT_TEST_TABLE");
-        Deencapsulation.setField(sut, mockStatement);
+        ReflectionUtil.setFieldValue(sut, "statement", mockStatement);
 
         assertThat("初回はtrue", sut.getMoreResults(), is(true));
         assertThat("2回目はfalse", sut.getMoreResults(), is(false));
@@ -2548,13 +2517,12 @@ public abstract class BasicSqlPStatementTestLogic {
      * DbAccessExceptionが送出されること。
      */
     @Test(expected = DbAccessException.class)
-    public void getMoreResults_SQLException(@Mocked final PreparedStatement mockStatement) throws Exception {
-        new Expectations() {{
-            mockStatement.getMoreResults();
-            result = new SQLException("getMoreResults error");
-        }};
+    public void getMoreResults_SQLException() throws Exception {
+        final PreparedStatement mockStatement = mock(PreparedStatement.class);
+
+        when(mockStatement.getMoreResults()).thenThrow(new SQLException("getMoreResults error"));
         final SqlPStatement sut = dbCon.prepareStatement("select * from STATEMENT_TEST_TABLE");
-        Deencapsulation.setField(sut, mockStatement);
+        ReflectionUtil.setFieldValue(sut, "statement", mockStatement);
         sut.getMoreResults();
     }
 
@@ -2811,14 +2779,13 @@ public abstract class BasicSqlPStatementTestLogic {
      * 例外が送出されること。
      */
     @Test(expected = DbAccessException.class)
-    public void retrieve_map_SQLException(@Mocked final PreparedStatement mockStatement) throws Exception {
-        new Expectations() {{
-            mockStatement.setObject(anyInt, any);
-            result = new SQLException("retrieve map error");
-        }};
+    public void retrieve_map_SQLException() throws Exception {
+        final PreparedStatement mockStatement = mock(PreparedStatement.class);
+
+        doThrow(new SQLException("retrieve map error")).when(mockStatement).setObject(anyInt(), any());
         final ParameterizedSqlPStatement sut = dbCon.prepareParameterizedSqlStatement(
                 "SELECT * FROM STATEMENT_TEST_TABLE WHERE ENTITY_ID = :id AND VARCHAR_COL = :varcharCol ORDER BY ENTITY_ID");
-        Deencapsulation.setField(sut, mockStatement);
+        ReflectionUtil.setFieldValue(sut, "statement", mockStatement);
 
         Map<String, String> condition = new HashMap<String, String>();
         condition.put("id", "10002");
@@ -3290,7 +3257,9 @@ public abstract class BasicSqlPStatementTestLogic {
      * 例外が送出されること。
      */
     @Test(expected = DbAccessException.class)
-    public void retrieve_object_SQLException(@Mocked final PreparedStatement mockStatement) throws Exception {
+    public void retrieve_object_SQLException() throws Exception {
+        final PreparedStatement mockStatement = mock(PreparedStatement.class);
+
         doRetrieve_object_SQLException(mockStatement, false);
     }
 
@@ -3299,19 +3268,17 @@ public abstract class BasicSqlPStatementTestLogic {
      * 例外が送出されること。(Fieldアクセステスト用)
      */
     @Test(expected = DbAccessException.class)
-    public void retrieve_object_SQLExceptionViaFieldAccess(@Mocked final PreparedStatement mockStatement) throws Exception {
+    public void retrieve_object_SQLExceptionViaFieldAccess() throws Exception {
+        final PreparedStatement mockStatement = mock(PreparedStatement.class);
+
         doRetrieve_object_SQLException(mockStatement, true);
     }
 
-    private void doRetrieve_object_SQLException(@Mocked final PreparedStatement mockStatement, final boolean isFieldAccess) throws
-            SQLException {
-        new Expectations() {{
-            mockStatement.setObject(anyInt, any);
-            result = new SQLException("retrieve map error");
-        }};
+    private void doRetrieve_object_SQLException(final PreparedStatement mockStatement, final boolean isFieldAccess) throws SQLException {
+        doThrow(new SQLException("retrieve map error")).when(mockStatement).setObject(anyInt(), any());
         final ParameterizedSqlPStatement sut = dbCon.prepareParameterizedSqlStatement(
                 "SELECT * FROM STATEMENT_TEST_TABLE WHERE ENTITY_ID = :id AND VARCHAR_COL = :varcharCol ORDER BY ENTITY_ID");
-        Deencapsulation.setField(sut, mockStatement);
+        ReflectionUtil.setFieldValue(sut, "statement", mockStatement);
         final Object condition;
         if (!isFieldAccess) {
             final TestEntity entity = new TestEntity();
@@ -3350,15 +3317,14 @@ public abstract class BasicSqlPStatementTestLogic {
      * {@link BasicSqlPStatement#executeQueryByMap(Map)}のSQLExceptionのテスト。
      */
     @Test(expected = DbAccessException.class)
-    public void executeQueryByMap_SQLException(@Mocked final PreparedStatement mockStatement) throws Exception {
-        new Expectations() {{
-            mockStatement.setObject(anyInt, any);
-            result = new SQLException("executeQuery map error");
-        }};
+    public void executeQueryByMap_SQLException() throws Exception {
+        final PreparedStatement mockStatement = mock(PreparedStatement.class);
+
+        doThrow(new SQLException("executeQuery map error")).when(mockStatement).setObject(anyInt(), any());
         final ParameterizedSqlPStatement sut = dbCon.prepareParameterizedSqlStatement(
                 "SELECT * FROM STATEMENT_TEST_TABLE WHERE ENTITY_ID = :id");
 
-        Deencapsulation.setField(sut, mockStatement);
+        ReflectionUtil.setFieldValue(sut, "statement", mockStatement);
         Map<String, String> condition = new HashMap<String, String>();
         condition.put("id", "10002");
         sut.executeQueryByMap(condition);
@@ -3406,7 +3372,9 @@ public abstract class BasicSqlPStatementTestLogic {
      * {@link BasicSqlPStatement#executeQueryByObject(Object)}のSQLExceptionのテスト。
      */
     @Test(expected = SqlStatementException.class)
-    public void executeQueryByObject_SQLException(@Mocked final PreparedStatement mockStatement) throws Exception {
+    public void executeQueryByObject_SQLException() throws Exception {
+        final PreparedStatement mockStatement = mock(PreparedStatement.class);
+
         doExecuteQueryByObject_SQLException(mockStatement, false);
     }
 
@@ -3414,19 +3382,18 @@ public abstract class BasicSqlPStatementTestLogic {
      * {@link BasicSqlPStatement#executeQueryByObject(Object)}のSQLExceptionのテスト。(Fieldアクセステスト用)
      */
     @Test(expected = SqlStatementException.class)
-    public void executeQueryByObject_SQLExceptionViaFieldAccess(@Mocked final PreparedStatement mockStatement) throws Exception {
+    public void executeQueryByObject_SQLExceptionViaFieldAccess() throws Exception {
+        final PreparedStatement mockStatement = mock(PreparedStatement.class);
+
         doExecuteQueryByObject_SQLException(mockStatement, true);
     }
 
     private void doExecuteQueryByObject_SQLException(final PreparedStatement mockStatement, final boolean isFieldAccess) throws
             SQLException {
-        new Expectations() {{
-            mockStatement.setObject(anyInt, any);
-            result = new SQLException("executeQuery object error");
-        }};
+        doThrow(new SQLException("executeQuery object error")).when(mockStatement).setObject(anyInt(), any());
         final ParameterizedSqlPStatement sut = dbCon.prepareParameterizedSqlStatement(
                 "SELECT * FROM STATEMENT_TEST_TABLE WHERE ENTITY_ID = :id");
-        Deencapsulation.setField(sut, mockStatement);
+        ReflectionUtil.setFieldValue(sut, "statement", mockStatement);
 
         final Object data;
         if(!isFieldAccess){
@@ -3470,14 +3437,13 @@ public abstract class BasicSqlPStatementTestLogic {
      * SqlStatementExceptionが送出されること。
      */
     @Test(expected = SqlStatementException.class)
-    public void executeUpdateByMap_SQLException(@Mocked final PreparedStatement mockStatement) throws Exception {
-        new Expectations() {{
-            mockStatement.setObject(anyInt, any);
-            result = new SQLException("executeUpdate map error");
-        }};
+    public void executeUpdateByMap_SQLException() throws Exception {
+        final PreparedStatement mockStatement = mock(PreparedStatement.class);
+
+        doThrow(new SQLException("executeUpdate map error")).when(mockStatement).setObject(anyInt(), any());
         final ParameterizedSqlPStatement sut = dbCon.prepareParameterizedSqlStatement(
                 "INSERT INTO STATEMENT_TEST_TABLE (ENTITY_ID, LONG_COL, BINARY_COL) VALUES (:id, :long, :binary)");
-        Deencapsulation.setField(sut, mockStatement);
+        ReflectionUtil.setFieldValue(sut, "statement", mockStatement);
         Map<String, Object> insertData = new HashMap<String, Object>();
         insertData.put("id", "44444");
         insertData.put("long", 100L);
@@ -3532,7 +3498,9 @@ public abstract class BasicSqlPStatementTestLogic {
      * {@link BasicSqlPStatement#executeUpdateByObject(Object)}のテスト。
      */
     @Test(expected = SqlStatementException.class)
-    public void executeUpdateByObject_SQLException(@Mocked final PreparedStatement mockStatement) throws Exception {
+    public void executeUpdateByObject_SQLException() throws Exception {
+        final PreparedStatement mockStatement = mock(PreparedStatement.class);
+
         doExecuteUpdateByObject_SQLException(mockStatement, false);
     }
 
@@ -3540,19 +3508,18 @@ public abstract class BasicSqlPStatementTestLogic {
      * {@link BasicSqlPStatement#executeUpdateByObject(Object)}のテスト。(Fieldアクセステスト用)
      */
     @Test(expected = SqlStatementException.class)
-    public void executeUpdateByObject_SQLExceptionViaFieldAccess(@Mocked final PreparedStatement mockStatement) throws Exception {
+    public void executeUpdateByObject_SQLExceptionViaFieldAccess() throws Exception {
+        final PreparedStatement mockStatement = mock(PreparedStatement.class);
+
         doExecuteUpdateByObject_SQLException(mockStatement, true);
     }
 
     private void doExecuteUpdateByObject_SQLException(final PreparedStatement mockStatement, final boolean isFieldAccess) throws
             SQLException {
-        new Expectations() {{
-            mockStatement.setObject(anyInt, any);
-            result = new SQLException("executeUpdate object error");
-        }};
+        doThrow(new SQLException("executeUpdate object error")).when(mockStatement).setObject(anyInt(), any());
         final ParameterizedSqlPStatement sut = dbCon.prepareParameterizedSqlStatement(
                 "INSERT INTO STATEMENT_TEST_TABLE (ENTITY_ID, LONG_COL, BINARY_COL) VALUES (:id, :long, :binary)");
-        Deencapsulation.setField(sut, mockStatement);
+        ReflectionUtil.setFieldValue(sut, "statement", mockStatement);
         final Object data;
         if(!isFieldAccess){
             final TestEntity entity = new TestEntity();
@@ -3608,14 +3575,13 @@ public abstract class BasicSqlPStatementTestLogic {
      * DbAccessExceptionが送出されること。
      */
     @Test(expected = DbAccessException.class)
-    public void addBatchMap_SQLException(@Mocked final PreparedStatement mockStatement) throws Exception {
-        new Expectations() {{
-            mockStatement.setObject(anyInt, any);
-            result = new SQLException("addBatch map error");
-        }};
+    public void addBatchMap_SQLException() throws Exception {
+        final PreparedStatement mockStatement = mock(PreparedStatement.class);
+
+        doThrow(new SQLException("addBatch map error")).when(mockStatement).setObject(anyInt(), any());
         final ParameterizedSqlPStatement sut = dbCon.prepareParameterizedSqlStatement(
                 "INSERT INTO STATEMENT_TEST_TABLE (ENTITY_ID, LONG_COL, BINARY_COL) VALUES (:id, :long, :binary)");
-        Deencapsulation.setField(sut, mockStatement);
+        ReflectionUtil.setFieldValue(sut, "statement", mockStatement);
         Map<String, Object> insertData = new HashMap<String, Object>();
         insertData.put("id", "44444");
         insertData.put("long", 100L);
@@ -3687,7 +3653,9 @@ public abstract class BasicSqlPStatementTestLogic {
      * DbAccessExceptionが送出されること。
      */
     @Test(expected = DbAccessException.class)
-    public void addBatchObject_SQLException(@Mocked final PreparedStatement mockStatement) throws Exception {
+    public void addBatchObject_SQLException() throws Exception {
+        final PreparedStatement mockStatement = mock(PreparedStatement.class);
+
         doAddBatchObject_SQLException(mockStatement, false);
     }
 
@@ -3696,19 +3664,18 @@ public abstract class BasicSqlPStatementTestLogic {
      * DbAccessExceptionが送出されること。(Fieldアクセステスト用)
      */
     @Test(expected = DbAccessException.class)
-    public void addBatchObject_SQLExceptionViaFieldAccess(@Mocked final PreparedStatement mockStatement) throws Exception {
+    public void addBatchObject_SQLExceptionViaFieldAccess() throws Exception {
+        final PreparedStatement mockStatement = mock(PreparedStatement.class);
+
         doAddBatchObject_SQLException(mockStatement, true);
     }
 
     private void doAddBatchObject_SQLException(final PreparedStatement mockStatement, final boolean isFieldAccess) throws
             SQLException {
-        new Expectations() {{
-            mockStatement.setObject(anyInt, any);
-            result = new SQLException("addBatch object error");
-        }};
+        doThrow(new SQLException("addBatch object error")).when(mockStatement).setObject(anyInt(), any());
         final ParameterizedSqlPStatement sut = dbCon.prepareParameterizedSqlStatement(
                 "INSERT INTO STATEMENT_TEST_TABLE (ENTITY_ID, LONG_COL, BINARY_COL) VALUES (:id, :long, :binary)");
-        Deencapsulation.setField(sut, mockStatement);
+        ReflectionUtil.setFieldValue(sut, "statement", mockStatement);
         final Object data;
         if(!isFieldAccess){
             final TestEntity entity = new TestEntity();
@@ -4005,13 +3972,12 @@ public abstract class BasicSqlPStatementTestLogic {
      * DbAccessExceptionが送出されること。
      */
     @Test(expected = DbAccessException.class)
-    public void getGeneratedKeys_SQLException(@Mocked final PreparedStatement mockStatement) throws Exception {
-        new Expectations() {{
-            mockStatement.getGeneratedKeys();
-            result = new SQLException("getGeneratedKeys error");
-        }};
+    public void getGeneratedKeys_SQLException() throws Exception {
+        final PreparedStatement mockStatement = mock(PreparedStatement.class);
+
+        when(mockStatement.getGeneratedKeys()).thenThrow(new SQLException("getGeneratedKeys error"));
         SqlPStatement sut = dbCon.prepareStatement("INSERT INTO STATEMENT_TEST_TABLE (ENTITY_ID) VALUES ('12345')");
-        Deencapsulation.setField(sut, mockStatement);
+        ReflectionUtil.setFieldValue(sut, "statement", mockStatement);
         sut.getGeneratedKeys();
     }
 
@@ -4074,17 +4040,16 @@ public abstract class BasicSqlPStatementTestLogic {
      * {@link BasicSqlPStatement#clearParameters()} のテスト。
      */
     @Test
-    public void clearParameters(@Mocked final PreparedStatement mockStatement) throws Exception {
+    public void clearParameters() throws Exception {
+        final PreparedStatement mockStatement = mock(PreparedStatement.class);
+
         final SqlPStatement sut = dbCon.prepareStatement(
                 "SELECT * FROM STATEMENT_TEST_TABLE WHERE ENTITY_ID = ?");
-        Deencapsulation.setField(sut, mockStatement);
+        ReflectionUtil.setFieldValue(sut, "statement", mockStatement);
         sut.setString(1, "10001");
         sut.clearParameters();
 
-        new Verifications(){{
-            mockStatement.clearParameters();
-            times = 1;
-        }};
+        verify(mockStatement).clearParameters();
     }
 
     /**
@@ -4092,14 +4057,13 @@ public abstract class BasicSqlPStatementTestLogic {
      * DbAccessExceptionが送出されること
      */
     @Test(expected = DbAccessException.class)
-    public void clearParameters_SQLException(@Mocked final PreparedStatement mockStatement) throws Exception {
-        new Expectations() {{
-            mockStatement.clearParameters();
-            result = new SQLException("clearParameters error");
-        }};
+    public void clearParameters_SQLException() throws Exception {
+        final PreparedStatement mockStatement = mock(PreparedStatement.class);
+
+        doThrow(new SQLException("clearParameters error")).when(mockStatement).clearParameters();
         final SqlPStatement sut = dbCon.prepareStatement(
                 "SELECT * FROM STATEMENT_TEST_TABLE WHERE ENTITY_ID = ?");
-        Deencapsulation.setField(sut, mockStatement);
+        ReflectionUtil.setFieldValue(sut, "statement", mockStatement);
         sut.clearParameters();
     }
 

--- a/src/test/java/nablarch/core/db/statement/BasicSqlParameterParserFactoryTest.java
+++ b/src/test/java/nablarch/core/db/statement/BasicSqlParameterParserFactoryTest.java
@@ -1,16 +1,14 @@
 package nablarch.core.db.statement;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import nablarch.core.db.statement.sqlconvertor.VariableInSyntaxConvertor;
+import nablarch.test.support.reflection.ReflectionUtil;
+import org.junit.Test;
 
 import java.util.Collections;
 
-import nablarch.core.db.statement.sqlconvertor.VariableInSyntaxConvertor;
-
-import org.junit.Test;
-
-import mockit.Deencapsulation;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
 
 /**
  * {@link BasicSqlParameterParserFactory}のテストクラス。
@@ -35,7 +33,7 @@ public class BasicSqlParameterParserFactoryTest {
     public void createSqlParameterParserFromCustomSetting() throws Exception {
         sut.setSqlConvertors(Collections.<SqlConvertor>singletonList(new VariableInSyntaxConvertor()));
         final SqlParameterParser parser = sut.createSqlParameterParser();
-        final SqlConvertor[] convertors = Deencapsulation.getField(parser, "sqlConvertors");
+        final SqlConvertor[] convertors = ReflectionUtil.getFieldValue(parser, "sqlConvertors");
         assertThat(convertors.length, is(1));
         assertThat(convertors[0], is(instanceOf(VariableInSyntaxConvertor.class)));
     }

--- a/src/test/java/nablarch/core/db/statement/BasicStatementFactoryTestLogic.java
+++ b/src/test/java/nablarch/core/db/statement/BasicStatementFactoryTestLogic.java
@@ -1,20 +1,9 @@
 package nablarch.core.db.statement;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
-
-import java.sql.Connection;
-import java.sql.SQLException;
-import java.sql.Statement;
-import java.util.HashMap;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-
 import nablarch.core.db.DbExecutionContext;
 import nablarch.core.db.connection.TransactionManagerConnection;
 import nablarch.core.db.dialect.DefaultDialect;
@@ -22,15 +11,23 @@ import nablarch.core.transaction.TransactionContext;
 import nablarch.test.support.db.helper.DatabaseTestRunner;
 import nablarch.test.support.db.helper.TargetDb;
 import nablarch.test.support.db.helper.VariousDbTestHelper;
-
+import nablarch.test.support.reflection.ReflectionUtil;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import mockit.Deencapsulation;
-import mockit.Mocked;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.HashMap;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
 
 /**
  * {@link BasicStatementFactory}のテストクラス。
@@ -89,7 +86,7 @@ public abstract class BasicStatementFactoryTestLogic {
         SqlPStatement statement = sut.getSqlPStatement(
                 "SELECT * FROM STATEMENT_FACTORY_TEST", connection, createContext(), new SelectOption(10, 20));
 
-        SelectOption selectOption = (SelectOption) Deencapsulation.getField(statement, "selectOption");
+        SelectOption selectOption = ReflectionUtil.getFieldValue(statement, "selectOption");
         assertThat(selectOption.getStartPosition(), is(10));
         assertThat(selectOption.getLimit(), is(20));
     }
@@ -190,7 +187,7 @@ public abstract class BasicStatementFactoryTestLogic {
         ParameterizedSqlPStatement statement = sut.getParameterizedSqlPStatement(
                 "SELECT '1' FROM STATEMENT_FACTORY_TEST", connection, createContext(), new SelectOption(10, 20));
 
-        SelectOption selectOption = (SelectOption) Deencapsulation.getField(statement, "selectOption");
+        SelectOption selectOption = ReflectionUtil.getFieldValue(statement, "selectOption");
         assertThat(selectOption.getStartPosition(), is(10));
         assertThat(selectOption.getLimit(), is(20));
     }
@@ -356,8 +353,7 @@ public abstract class BasicStatementFactoryTestLogic {
         }
     }
 
-    @Mocked
-    private TransactionManagerConnection mockConnection;
+    private final TransactionManagerConnection mockConnection = mock(TransactionManagerConnection.class);
 
     /**
      * DBアクセス時の実行時のコンテキストを生成する。

--- a/src/test/java/nablarch/core/db/statement/exception/BasicSqlStatementExceptionFactoryTest.java
+++ b/src/test/java/nablarch/core/db/statement/exception/BasicSqlStatementExceptionFactoryTest.java
@@ -1,30 +1,26 @@
 package nablarch.core.db.statement.exception;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import nablarch.core.db.DbExecutionContext;
+import nablarch.core.db.dialect.Dialect;
+import org.junit.Test;
 
 import java.sql.SQLException;
 
-import nablarch.core.db.DbExecutionContext;
-import nablarch.core.db.dialect.Dialect;
-
-import org.junit.Ignore;
-import org.junit.Test;
-
-import mockit.Expectations;
-import mockit.Mocked;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * {@link BasicSqlStatementExceptionFactory}のテストクラス。<br>
  *
  * @author Hisaaki Sioiri
  */
-@Ignore("jacoco と jmockit が競合してエラーになるため")
 public class BasicSqlStatementExceptionFactoryTest {
 
-    @Mocked
-    private DbExecutionContext context;
+    private final DbExecutionContext context = mock(DbExecutionContext.class, RETURNS_DEEP_STUBS);
     private BasicSqlStatementExceptionFactory factory = new BasicSqlStatementExceptionFactory();
 
     /**
@@ -37,11 +33,10 @@ public class BasicSqlStatementExceptionFactoryTest {
     public void testCreateSqlStatementExceptionIsDuplicateException() {
 
         final SQLException sqle = new SQLException("message", "E001", 1);
-        new Expectations() {{
-            Dialect dialect = context.getDialect();
-            dialect.isDuplicateException(sqle);
-            result = true;
-        }};
+        
+        Dialect dialect = context.getDialect();
+        when(dialect.isDuplicateException(sqle)).thenReturn(true);
+        
         SqlStatementException sqlStatementException = factory.createSqlStatementException("一意制約違反と判定するDialect", sqle, context);
         assertThat("一意制約違反のExceptionである。", sqlStatementException, instanceOf(DuplicateStatementException.class));
         assertThat("メッセージ比較", sqlStatementException.getMessage(), is("一意制約違反と判定するDialect"));
@@ -55,11 +50,10 @@ public class BasicSqlStatementExceptionFactoryTest {
     @Test
     public void testCreateSqlStatementExceptionIsNotDuplicateException() {
         final SQLException sqle2 = new SQLException("message", "E001", 1);
-        new Expectations() {{
-            Dialect dialect = context.getDialect();
-            dialect.isDuplicateException(sqle2);
-            result = false;
-        }};
+        
+        Dialect dialect = context.getDialect();
+        when(dialect.isDuplicateException(sqle2)).thenReturn(false);
+        
         SqlStatementException sqlStatementException2 = factory.createSqlStatementException("一意制約違反と判定しないDialect", sqle2, context);
         assertThat("一意制約違反のExceptionでない。", sqlStatementException2, instanceOf(SqlStatementException.class));
         assertThat("メッセージ比較", sqlStatementException2.getMessage(), is("一意制約違反と判定しないDialect"));

--- a/src/test/java/nablarch/core/db/support/DbAccessSupportTest.java
+++ b/src/test/java/nablarch/core/db/support/DbAccessSupportTest.java
@@ -1,27 +1,13 @@
 package nablarch.core.db.support;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
-
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.SQLException;
-import java.sql.Types;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-
-import nablarch.core.db.connection.AppDbConnection;
-import nablarch.core.db.connection.DbConnectionContext;
 import nablarch.core.db.dialect.Dialect;
 import nablarch.core.db.dialect.OracleDialect;
 import nablarch.core.db.statement.BasicSqlLoader;
+import nablarch.core.db.statement.BasicSqlPStatement;
 import nablarch.core.db.statement.ParameterizedSqlPStatement;
 import nablarch.core.db.statement.ResultSetIterator;
 import nablarch.core.db.statement.SqlCStatement;
@@ -32,16 +18,29 @@ import nablarch.test.support.SystemRepositoryResource;
 import nablarch.test.support.db.helper.DatabaseTestRunner;
 import nablarch.test.support.db.helper.TargetDb;
 import nablarch.test.support.db.helper.VariousDbTestHelper;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.MockedConstruction;
 
-import mockit.Expectations;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.when;
 
 /**
  * {@link DbAccessSupport}のテストクラス。
@@ -224,19 +223,16 @@ public class DbAccessSupportTest extends DbAccessSupport {
      * ※本来はありえないため、モックを使って実現する。
      */
     @Test(expected = IllegalStateException.class)
-    @Ignore("jacoco と jmockit が競合してエラーになるため")
     public void testCountByParameterizedSql_recordNotFound() throws Exception {
-        final AppDbConnection connection = DbConnectionContext.getConnection();
-        new Expectations(connection) {{
-            final ParameterizedSqlPStatement st = connection.prepareParameterizedCountSqlStatementBySqlId(
-                    anyString, any);
+        try (final MockedConstruction<BasicSqlPStatement> mocked = mockConstruction(BasicSqlPStatement.class, (mock, context) -> {
+            ResultSetIterator rs = mock(ResultSetIterator.class);
+            when(mock.executeQueryByObject(any())).thenReturn(rs);
+            when(rs.next()).thenReturn(false);
+        })) {
 
-            final ResultSetIterator rows = st.executeQueryByObject(any);
-            rows.next(); result = false;
-        }};
-
-        DbAccessSupport support = new DbAccessSupport(getClass());
-        support.countByParameterizedSql("SQL001", new Object());
+            DbAccessSupport support = new DbAccessSupport(getClass());
+            support.countByParameterizedSql("SQL001", new Object());
+        }
     }
 
     public class ListSearchInfoImpl extends ListSearchInfo {

--- a/src/test/java/nablarch/core/db/transaction/JdbcTransactionTest.java
+++ b/src/test/java/nablarch/core/db/transaction/JdbcTransactionTest.java
@@ -1,25 +1,24 @@
 package nablarch.core.db.transaction;
 
+import nablarch.core.db.connection.DbConnectionContext;
+import nablarch.core.db.connection.TransactionManagerConnection;
+import nablarch.test.support.log.app.OnMemoryLogWriter;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
 import java.sql.Connection;
 import java.util.ArrayList;
 import java.util.Collections;
 
-import nablarch.core.db.connection.DbConnectionContext;
-import nablarch.core.db.connection.TransactionManagerConnection;
-import nablarch.test.support.log.app.OnMemoryLogWriter;
-
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
-
-import mockit.Mocked;
-import mockit.Verifications;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 /**
  * {@link JdbcTransaction}のテスト。
  */
-@Ignore("jacoco と jmockit が競合してエラーになるため")
 public class JdbcTransactionTest {
 
     /** テストで使うコネクション名 */
@@ -28,11 +27,9 @@ public class JdbcTransactionTest {
     /** テスト対象 */
     private JdbcTransaction sut;
 
-    @Mocked
-    private TransactionManagerConnection mockConnection;
+    private final TransactionManagerConnection mockConnection = mock(TransactionManagerConnection.class, RETURNS_DEEP_STUBS);
 
-    @Mocked
-    private JdbcTransactionTimeoutHandler mockTimeoutHandler;
+    private final JdbcTransactionTimeoutHandler mockTimeoutHandler = mock(JdbcTransactionTimeoutHandler.class);
 
     @Before
     public void setUp() throws Exception {
@@ -55,11 +52,8 @@ public class JdbcTransactionTest {
         sut.setIsolationLevel(Connection.TRANSACTION_SERIALIZABLE);
         sut.begin();
 
-        new Verifications() {{
-            // コネクションに対してトランザクション分離レベルが設定されたことを検証する。
-            mockConnection.setIsolationLevel(Connection.TRANSACTION_SERIALIZABLE);
-            times = 1;
-        }};
+        // コネクションに対してトランザクション分離レベルが設定されたことを検証する。
+        verify(mockConnection).setIsolationLevel(Connection.TRANSACTION_SERIALIZABLE);
     }
 
     /**
@@ -73,12 +67,8 @@ public class JdbcTransactionTest {
         }});
         sut.begin();
 
-        new Verifications() {{
-            mockConnection.prepareStatement("select 1 from table_name");
-            times = 1;
-            mockConnection.prepareStatement("select 2 from table_name2");
-            times = 1;
-        }};
+        verify(mockConnection).prepareStatement("select 1 from table_name");
+        verify(mockConnection).prepareStatement("select 2 from table_name2");
     }
 
     /**
@@ -89,10 +79,7 @@ public class JdbcTransactionTest {
         sut.begin();
         sut.commit();
 
-        new Verifications() {{
-            mockConnection.commit();
-            times = 1;
-        }};
+        verify(mockConnection).commit();
         OnMemoryLogWriter.assertLogContains("writer.memory", "transaction commit. resource=[connection name]");
     }
 
@@ -105,10 +92,7 @@ public class JdbcTransactionTest {
         sut.rollback();
 
         // ロールバックは、トランザクション開始時にも実行されるので、2回実行される。
-        new Verifications() {{
-            mockConnection.rollback();
-            times = 2;
-        }};
+        verify(mockConnection, times(2)).rollback();
         OnMemoryLogWriter.assertLogContains("writer.memory", "transaction rollback. resource=[connection name]");
     }
 
@@ -122,12 +106,8 @@ public class JdbcTransactionTest {
         sut.setTransactionTimeoutHandler(mockTimeoutHandler);
         sut.begin();
 
-        new Verifications() {{
-            mockTimeoutHandler.begin();
-            times = 1;
-            mockConnection.setJdbcTransactionTimeoutHandler(mockTimeoutHandler);
-            times = 1;
-        }};
+        verify(mockTimeoutHandler).begin();
+        verify(mockConnection).setJdbcTransactionTimeoutHandler(mockTimeoutHandler);
     }
 }
 

--- a/src/test/java/nablarch/core/db/util/DbUtilTest.java
+++ b/src/test/java/nablarch/core/db/util/DbUtilTest.java
@@ -1,14 +1,11 @@
 package nablarch.core.db.util;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.core.IsNull.nullValue;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import nablarch.core.repository.SystemRepository;
+import org.hamcrest.collection.IsMapContaining;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
-import java.lang.reflect.Field;
-import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
@@ -16,17 +13,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Vector;
 
-import org.hamcrest.collection.IsMapContaining;
-
-import nablarch.core.repository.SystemRepository;
-
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
-
-import mockit.Mock;
-import mockit.MockUp;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.core.IsNull.nullValue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * {@link DbUtil}のテストクラス。
@@ -225,39 +217,6 @@ public class DbUtilTest {
         } catch (IllegalArgumentException e) {
             assertThat("存在しないフィールドへのアクセスでは例外を送出", e.getMessage(),
                     is("specified filed [notExistingField] is not declared in the class [nablarch.core.db.util.DbUtilTest$DbUtilTestEntity]."));
-        }
-    }
-
-    /**
-     * {@link DbUtil#getField(Object, String)} の異常系テスト
-     * IllegalAccessExceptionは通常発生しないため、Mockを使って送出している。
-     * @throws Exception
-     */
-    @Test
-    @Ignore("jacoco と jmockit が競合してエラーになるため")
-    public void testGetFiledErrorIllegalAccessException(/*@Mocked final Field mockedField*/) throws Exception {
-        Object grandObjectValue = new Object();
-        Object parentObjectValue = new Object();
-        Object objectValue = new Object();
-        final DbUtilTestEntity bean = new DbUtilTestEntity(
-                "grandPrivateStringValue", -3, -2L, grandObjectValue,
-                "parentPrivateStringValue", -1, 0L, parentObjectValue,
-                "privateStringValue", 1, 2L, objectValue);
-        final String fieldName = "privateString";
-        new MockUp<DbUtil>() {
-            @Mock
-            private Field findDeclaredField(final Class<?> clazz, final String fieldName) throws IllegalAccessException
-            {
-                throw new IllegalAccessException();
-            }
-        };
-        try {
-            Object value = DbUtil.getField(bean, fieldName);
-        }
-        catch(RuntimeException e)
-        {
-            assertThat("メッセージが一致するか", e.getMessage(),
-                    is("failed to access the filed [privateString]  of the class [nablarch.core.db.util.DbUtilTest$DbUtilTestEntity].") );
         }
     }
 


### PR DESCRIPTION
- `DbAccessSupportTest` の `testCountByParameterizedSql_recordNotFound` で、元は `connection` を部分モックにしていたのに修正後は `BasicSqlPStatement` のコンストラクタをモック化している理由
  - jmockit の部分モックをそのまま mockito に置き換えると `spy` になるが、 `spy` は元のオブジェクトは変更せずに `spy` にした新しいオブジェクトを生成する仕組みになっている
  - このため、 `DbConnectionContext` が内部で保持している `connection` 自体を `spy` に置き換えることができない
    - `DbConnectionContext.setConnection()` は、同じ名前のコネクションを上書きできない仕組みになっている
  - このため、 `connection` を `spy` にするのではなく、内部で生成されている `BasicSqlPStatement` をモックにして元の処理を再現させるようにした

- `DbUtilTest` の `testGetFiledErrorIllegalAccessException` を削除している理由
  - このテストはリフレクションでフィールドにアクセスするときに `IllegalAccessException` がスローされた場合をテストしようとしている
  - しかし、フィールドアクセス前には `setAccessible(true)` をしているため `IllegalAccessException` がスローされることはない
  - このため、 `DbUtil` の private メソッドである `findDeclaredField` をモック化して無理矢理例外をスローさせている
  - jmockit は private メソッドのモック化もできたが、**mockito の inline mock maker では private メソッドのモック化はできない**
  - そもそも起こりえないケースを無理にテストしようとしているものなので、 `DbUtil` の実装上に `IllegalAccessException` はスローされないことをコメントで補足してテストケースを削除することにした