### PR TITLE
finally句で握り潰しているErrorを伝播させる

### DIFF
--- a/src/main/java/nablarch/core/db/transaction/SimpleDbTransactionExecutor.java
+++ b/src/main/java/nablarch/core/db/transaction/SimpleDbTransactionExecutor.java
@@ -47,6 +47,7 @@ public abstract class SimpleDbTransactionExecutor<T> {
     public T doTransaction() {
         transactionManager.beginTransaction();
 
+        Throwable throwable = null;
         try {
             T result = execute(DbConnectionContext.getConnection(
                     transactionManager.getDbTransactionName()));
@@ -58,22 +59,27 @@ public abstract class SimpleDbTransactionExecutor<T> {
                 transactionManager.rollbackTransaction();
             } catch (RuntimeException exception) {
                 writeWarnLog(e);
+                throwable = exception;
                 throw exception;
             } catch (Error error) {
                 writeWarnLog(e);
+                throwable = error;
                 throw error;
             }
+            throwable = e;
             throw e;
         } catch (Error e) {
             try {
                 transactionManager.rollbackTransaction();
             } catch (RuntimeException exception) {
-                writeWarnLog(e);
-                throw exception;
+                // execute/commitでErrorが発生している場合はrollbackのRuntimeExceptionよりErrorを優先する
+                writeWarnLog(exception);
             } catch (Error error) {
                 writeWarnLog(e);
+                throwable = error;
                 throw error;
             }
+            throwable = e;
             throw e;
         } finally {
             try {
@@ -81,7 +87,16 @@ public abstract class SimpleDbTransactionExecutor<T> {
             } catch (RuntimeException e) {
                 writeWarnLog(e);
             } catch (Error e) {
-                writeWarnLog(e);
+                // endTransactionではコネクションの後処理しかしていないため
+                // 業務処理で既にErrorが発生している場合、業務処理のErrorを優先する
+                if(throwable instanceof Error){
+                    writeWarnLog(e);
+                    throw (Error)throwable;
+                }
+                if(throwable != null) {
+                    writeWarnLog(throwable);
+                }
+                throw e;
             }
         }
     }

--- a/src/main/java/nablarch/core/db/transaction/SimpleDbTransactionExecutor.java
+++ b/src/main/java/nablarch/core/db/transaction/SimpleDbTransactionExecutor.java
@@ -89,11 +89,11 @@ public abstract class SimpleDbTransactionExecutor<T> {
             } catch (Error e) {
                 // endTransactionではコネクションの後処理しかしていないため
                 // 業務処理で既にErrorが発生している場合、業務処理のErrorを優先する
-                if(throwable instanceof Error){
+                if (throwable instanceof Error) {
                     writeWarnLog(e);
-                    throw (Error)throwable;
+                    throw (Error) throwable;
                 }
-                if(throwable != null) {
+                if (throwable != null) {
                     writeWarnLog(throwable);
                 }
                 throw e;

--- a/src/test/java/nablarch/core/db/transaction/SimpleDbTransactionExecutorTest.java
+++ b/src/test/java/nablarch/core/db/transaction/SimpleDbTransactionExecutorTest.java
@@ -34,6 +34,12 @@ import org.junit.runner.RunWith;
 @RunWith(DatabaseTestRunner.class)
 public class SimpleDbTransactionExecutorTest {
 
+    public static final String EXECUTE_RUNTIME_EXCEPTION_MESSAGE = "runtime exception.";
+    public static final String EXECUTE_ERROR_MESSAGE = "Error.";
+    public static final String ROLLBACK_RUNTIME_EXCEPTION_MESSAGE = "rollback runtime exception.";
+    public static final String ROLLBACK_ERROR_MESSAGE = "rollback Error.";
+    public static final String END_RUNTIME_EXCEPTION_MESSAGE = "end runtime exception.";
+    public static final String END_ERROR_MESSAGE = "end Error.";
     /** テストターゲット */
     private SimpleDbTransactionManager transaction;
 
@@ -93,7 +99,7 @@ public class SimpleDbTransactionExecutorTest {
                     .doTransaction();
             fail("does not run.");
         } catch (Exception e) {
-            assertThat(e.getMessage(), is("runtime exception."));
+            assertThat(e.getMessage(), is(EXECUTE_RUNTIME_EXCEPTION_MESSAGE));
         }
         TestEntity entity = VariousDbTestHelper.findById(TestEntity.class, ID);
         assertThat("更新されていないこと", entity.col2, is(INIT_VALUE));
@@ -118,7 +124,7 @@ public class SimpleDbTransactionExecutorTest {
                     .doTransaction();
             fail("does not run.");
         } catch (Error e) {
-            assertThat(e.getMessage(), is("Error."));
+            assertThat(e.getMessage(), is(EXECUTE_ERROR_MESSAGE));
         }
 
         TestEntity entity = VariousDbTestHelper.findById(TestEntity.class, ID);
@@ -148,7 +154,7 @@ public class SimpleDbTransactionExecutorTest {
                     .doTransaction();
             fail("does not run.");
         } catch (RuntimeException e) {
-            assertThat(e.getMessage(), is("rollback runtime error."));
+            assertThat(e.getMessage(), is(ROLLBACK_RUNTIME_EXCEPTION_MESSAGE));
         }
 
         // 更新されていないことをアサート
@@ -157,7 +163,7 @@ public class SimpleDbTransactionExecutorTest {
 
         // ログのアサート
         assertWarnLogCountIs(1);
-        assertWarnLog("java.lang.RuntimeException: runtime exception");
+        assertWarnLog(EXECUTE_RUNTIME_EXCEPTION_MESSAGE);
     }
 
     /**
@@ -167,7 +173,7 @@ public class SimpleDbTransactionExecutorTest {
      * <ul>
      * <li>SQL実行時にRuntimeExceptionが発生し、ロールバック時にはErrorが発生する場合</li>
      * <li>呼び出し元には、ロールバック時に発生した例外が送出されること。</li>
-     * <li>SQL実行時に発生したRuntimeExceptionは、ワーニングレベルでログ出y力されること。</li>
+     * <li>SQL実行時に発生したRuntimeExceptionは、ワーニングレベルでログ出力されること。</li>
      * </ul>
      */
     @Test
@@ -181,7 +187,7 @@ public class SimpleDbTransactionExecutorTest {
                     .doTransaction();
             fail("does not run.");
         } catch (Error e) {
-            assertThat(e.getMessage(), is("rollback Error."));
+            assertThat(e.getMessage(), is(ROLLBACK_ERROR_MESSAGE));
         }
 
         TestEntity entity = VariousDbTestHelper.findById(TestEntity.class, ID);
@@ -189,7 +195,7 @@ public class SimpleDbTransactionExecutorTest {
 
         // ログのアサート
         assertWarnLogCountIs(1);
-        assertWarnLog("java.lang.RuntimeException: runtime exception");
+        assertWarnLog(EXECUTE_RUNTIME_EXCEPTION_MESSAGE);
     }
 
     /**
@@ -214,7 +220,7 @@ public class SimpleDbTransactionExecutorTest {
                     .doTransaction();
             fail("does not run.");
         } catch (Error e) {
-            assertThat(e.getMessage(), is("rollback Error."));
+            assertThat(e.getMessage(), is(ROLLBACK_ERROR_MESSAGE));
         }
 
         TestEntity entity = VariousDbTestHelper.findById(TestEntity.class, ID);
@@ -222,8 +228,8 @@ public class SimpleDbTransactionExecutorTest {
 
         // ログのアサート
         assertWarnLogCountIs(2);
-        assertWarnLog("java.lang.RuntimeException: runtime exception");
-        assertWarnLog("java.lang.RuntimeException: end runtime error");
+        assertWarnLog(EXECUTE_RUNTIME_EXCEPTION_MESSAGE);
+        assertWarnLog(END_RUNTIME_EXCEPTION_MESSAGE);
     }
 
     /**
@@ -232,8 +238,8 @@ public class SimpleDbTransactionExecutorTest {
      * <h2>テスト内容</h2>
      * <ul>
      * <li>SQL実行時にErrorが発生し、ロールバック時にはRuntimeExceptionが発生する場合</li>
-     * <li>呼び出し元には、ロールバック時に発生した例外が送出されること。</li>
-     * <li>SQL実行時のErrorは、ワーニングレベルでログ出力されること。</li>
+     * <li>呼び出し元には、SQL実行時に発生した例外が送出されること。</li>
+     * <li>ロールバック時のRuntimeExceptionは、ワーニングレベルでログ出力されること。</li>
      * </ul>
      */
     @Test
@@ -246,8 +252,8 @@ public class SimpleDbTransactionExecutorTest {
                             SimpleDbTransactionManagerError.ERROR_STATEMENT.ROLLBACK_RUNTIME))
                     .doTransaction();
             fail("does not run.");
-        } catch (RuntimeException e) {
-            assertThat(e.getMessage(), is("rollback runtime error."));
+        } catch (Error e) {
+            assertThat(e.getMessage(), is(EXECUTE_ERROR_MESSAGE));
         }
 
         TestEntity entity = VariousDbTestHelper.findById(TestEntity.class, ID);
@@ -255,7 +261,7 @@ public class SimpleDbTransactionExecutorTest {
 
         // ログのアサート
         assertWarnLogCountIs(1);
-        assertWarnLog("java.lang.Error: Error");
+        assertWarnLog(ROLLBACK_RUNTIME_EXCEPTION_MESSAGE);
     }
 
     /**
@@ -278,7 +284,7 @@ public class SimpleDbTransactionExecutorTest {
                     .doTransaction();
             fail("does not run.");
         } catch (Error e) {
-            assertThat(e.getMessage(), is("rollback Error."));
+            assertThat(e.getMessage(), is(ROLLBACK_ERROR_MESSAGE));
         }
 
         TestEntity entity = VariousDbTestHelper.findById(TestEntity.class, ID);
@@ -286,7 +292,7 @@ public class SimpleDbTransactionExecutorTest {
 
         // ログのアサート
         assertWarnLogCountIs(1);
-        assertWarnLog("java.lang.Error: Error");
+        assertWarnLog(EXECUTE_ERROR_MESSAGE);
     }
 
     /**
@@ -310,7 +316,7 @@ public class SimpleDbTransactionExecutorTest {
                     .doTransaction();
             fail("does not run.");
         } catch (Error e) {
-            assertThat(e.getMessage(), is("rollback Error."));
+            assertThat(e.getMessage(), is(ROLLBACK_ERROR_MESSAGE));
         }
 
         TestEntity entity = VariousDbTestHelper.findById(TestEntity.class, ID);
@@ -318,8 +324,8 @@ public class SimpleDbTransactionExecutorTest {
 
         // ログのアサート
         assertWarnLogCountIs(2);
-        assertWarnLog("java.lang.Error: Error");
-        assertWarnLog("java.lang.RuntimeException: end runtime error");
+        assertWarnLog(EXECUTE_ERROR_MESSAGE);
+        assertWarnLog(END_RUNTIME_EXCEPTION_MESSAGE);
     }
 
     /**
@@ -343,7 +349,7 @@ public class SimpleDbTransactionExecutorTest {
                     .doTransaction();
             fail("does not run.");
         } catch (Error e) {
-            assertThat(e.getMessage(), is("rollback Error."));
+            assertThat(e.getMessage(), is(ROLLBACK_ERROR_MESSAGE));
         }
 
         TestEntity entity = VariousDbTestHelper.findById(TestEntity.class, ID);
@@ -351,8 +357,8 @@ public class SimpleDbTransactionExecutorTest {
 
         // ログのアサート
         assertWarnLogCountIs(2);
-        assertWarnLog("java.lang.Error: Error");
-        assertWarnLog("java.lang.Error: end Error");
+        assertWarnLog(EXECUTE_ERROR_MESSAGE);
+        assertWarnLog(END_ERROR_MESSAGE);
     }
 
     /**
@@ -376,7 +382,7 @@ public class SimpleDbTransactionExecutorTest {
                     .doTransaction();
             fail("does not run.");
         } catch (RuntimeException e) {
-            assertThat(e.getMessage(), is("runtime exception."));
+            assertThat(e.getMessage(), is(EXECUTE_RUNTIME_EXCEPTION_MESSAGE));
         }
 
         TestEntity entity = VariousDbTestHelper.findById(TestEntity.class, ID);
@@ -384,7 +390,7 @@ public class SimpleDbTransactionExecutorTest {
 
         // ログのアサート
         assertWarnLogCountIs(1);
-        assertWarnLog("java.lang.RuntimeException: end runtime error");
+        assertWarnLog(END_RUNTIME_EXCEPTION_MESSAGE);
     }
 
     /**
@@ -393,7 +399,7 @@ public class SimpleDbTransactionExecutorTest {
      * <h2>テスト内容</h2>
      * <ul>
      * <li>SQL実行時にRuntimeExceptionが発生し、トランザクションの終了時にはErrorが発生する場合</li>
-     * <li>呼び出し元には、SQL実行時に発生した例外が送出されること。</li>
+     * <li>呼び出し元には、トランザクションの終了時に発生した例外が送出されること。</li>
      * <li>SQL実行時のRuntimeExceptionは、ワーニングレベルでログ出力されること。</li>
      * </ul>
      */
@@ -406,8 +412,8 @@ public class SimpleDbTransactionExecutorTest {
                             SimpleDbTransactionManagerError.ERROR_STATEMENT.END_ERROR))
                     .doTransaction();
             fail("does not run.");
-        } catch (RuntimeException e) {
-            assertThat(e.getMessage(), is("runtime exception."));
+        } catch (Error e) {
+            assertThat(e.getMessage(), is(END_ERROR_MESSAGE));
         }
 
         TestEntity entity = VariousDbTestHelper.findById(TestEntity.class, ID);
@@ -415,7 +421,7 @@ public class SimpleDbTransactionExecutorTest {
 
         // ログのアサート
         assertWarnLogCountIs(1);
-        assertWarnLog("java.lang.Error: end Error");
+        assertWarnLog(EXECUTE_RUNTIME_EXCEPTION_MESSAGE);
     }
 
     /**
@@ -425,7 +431,7 @@ public class SimpleDbTransactionExecutorTest {
      * <ul>
      * <li>SQL実行時にErrorが発生し、トランザクションの終了時にはRuntimeExceptionが発生する場合</li>
      * <li>呼び出し元には、SQL実行時に発生した例外が送出されること。</li>
-     * <li>SQL実行時のErrorは、ワーニングレベルでログ出力されること。</li>
+     * <li>トランザクションの終了時のRuntimeExceptionは、ワーニングレベルでログ出力されること。</li>
      * </ul>
      */
     @Test
@@ -439,7 +445,7 @@ public class SimpleDbTransactionExecutorTest {
                     .doTransaction();
             fail("does not run.");
         } catch (Error e) {
-            assertThat(e.getMessage(), is("Error."));
+            assertThat(e.getMessage(), is(EXECUTE_ERROR_MESSAGE));
         }
 
         TestEntity entity = VariousDbTestHelper.findById(TestEntity.class, ID);
@@ -447,7 +453,7 @@ public class SimpleDbTransactionExecutorTest {
 
         // ログのアサート
         assertWarnLogCountIs(1);
-        assertWarnLog("java.lang.RuntimeException: end runtime error");
+        assertWarnLog(END_RUNTIME_EXCEPTION_MESSAGE);
     }
 
     /**
@@ -470,7 +476,7 @@ public class SimpleDbTransactionExecutorTest {
                     .doTransaction();
             fail("does not run.");
         } catch (Error e) {
-            assertThat(e.getMessage(), is("Error."));
+            assertThat(e.getMessage(), is(EXECUTE_ERROR_MESSAGE));
         }
 
         TestEntity entity = VariousDbTestHelper.findById(TestEntity.class, ID);
@@ -478,7 +484,7 @@ public class SimpleDbTransactionExecutorTest {
 
         // ログのアサート
         assertWarnLogCountIs(1);
-        assertWarnLog("java.lang.Error: end Error");
+        assertWarnLog(END_ERROR_MESSAGE);
     }
 
     /**
@@ -488,7 +494,7 @@ public class SimpleDbTransactionExecutorTest {
      * <ul>
      * <li>SQL実行時にRuntimeExceptionが発生し、ロールバックとトランザクションの終了時にはRuntimeExceptionが発生する場合</li>
      * <li>呼び出し元には、ロールバック時に発生した例外が送出されること。</li>
-     * <li>SQL実行時とロールバック時のRuntimeExceptionは、ワーニングレベルでログ出力されること。</li>
+     * <li>SQL実行時とトランザクションの終了時のRuntimeExceptionは、ワーニングレベルでログ出力されること。</li>
      * </ul>
      */
     @Test
@@ -502,7 +508,7 @@ public class SimpleDbTransactionExecutorTest {
                     .doTransaction();
             fail("does not run.");
         } catch (RuntimeException e) {
-            assertThat(e.getMessage(), is("rollback runtime error."));
+            assertThat(e.getMessage(), is(ROLLBACK_RUNTIME_EXCEPTION_MESSAGE));
         }
 
         TestEntity entity = VariousDbTestHelper.findById(TestEntity.class, ID);
@@ -510,8 +516,8 @@ public class SimpleDbTransactionExecutorTest {
 
         // ログのアサート
         assertWarnLogCountIs(2);
-        assertWarnLog("java.lang.RuntimeException: runtime exception");
-        assertWarnLog("java.lang.RuntimeException: end runtime error");
+        assertWarnLog(EXECUTE_RUNTIME_EXCEPTION_MESSAGE);
+        assertWarnLog(END_RUNTIME_EXCEPTION_MESSAGE);
     }
 
     /**
@@ -520,7 +526,7 @@ public class SimpleDbTransactionExecutorTest {
      * <h2>テスト内容</h2>
      * <ul>
      * <li>SQL実行時にRuntimeExceptionが発生し、ロールバック時にはRuntimeExceptionが発生し、トランザクション終了時にはErrorがする場合</li>
-     * <li>呼び出し元には、ロールバック時に発生した例外が送出されること。</li>
+     * <li>呼び出し元には、トランザクション終了時に発生した例外が送出されること。</li>
      * <li>SQL実行時とロールバック時のRuntimeExceptionは、ワーニングレベルでログ出力されること。</li>
      * </ul>
      */
@@ -534,8 +540,8 @@ public class SimpleDbTransactionExecutorTest {
                             SimpleDbTransactionManagerError.ERROR_STATEMENT.END_ERROR))
                     .doTransaction();
             fail("does not run.");
-        } catch (RuntimeException e) {
-            assertThat(e.getMessage(), is("rollback runtime error."));
+        } catch (Error e) {
+            assertThat(e.getMessage(), is(END_ERROR_MESSAGE));
         }
 
         TestEntity entity = VariousDbTestHelper.findById(TestEntity.class, ID);
@@ -543,8 +549,8 @@ public class SimpleDbTransactionExecutorTest {
 
         // ログのアサート
         assertWarnLogCountIs(2);
-        assertWarnLog("java.lang.RuntimeException: runtime exception");
-        assertWarnLog("java.lang.Error: end Error");
+        assertWarnLog(EXECUTE_RUNTIME_EXCEPTION_MESSAGE);
+        assertWarnLog(ROLLBACK_RUNTIME_EXCEPTION_MESSAGE);
     }
 
     /**
@@ -553,8 +559,8 @@ public class SimpleDbTransactionExecutorTest {
      * <h2>テスト内容</h2>
      * <ul>
      * <li>SQL実行時にErrorが発生し、ロールバックとトランザクションの終了時にはRuntimeExceptionが発生する場合</li>
-     * <li>呼び出し元には、ロールバック時に発生した例外が送出されること。</li>
-     * <li>SQL実行時とロールバック時のRuntimeExceptionは、ワーニングレベルでログ出力されること。</li>
+     * <li>呼び出し元には、SQL実行時に発生した例外が送出されること。</li>
+     * <li>ロールバック時とトランザクションの終了時のRuntimeExceptionは、ワーニングレベルでログ出力されること。</li>
      * </ul>
      */
     @Test
@@ -567,8 +573,8 @@ public class SimpleDbTransactionExecutorTest {
                             SimpleDbTransactionManagerError.ERROR_STATEMENT.END_RUNTIME))
                     .doTransaction();
             fail("does not run.");
-        } catch (RuntimeException e) {
-            assertThat(e.getMessage(), is("rollback runtime error."));
+        } catch (Error e) {
+            assertThat(e.getMessage(), is(EXECUTE_ERROR_MESSAGE));
         }
 
 
@@ -577,8 +583,8 @@ public class SimpleDbTransactionExecutorTest {
 
         // ログのアサート
         assertWarnLogCountIs(2);
-        assertWarnLog("java.lang.Error: Error");
-        assertWarnLog("java.lang.RuntimeException: end runtime error");
+        assertWarnLog(ROLLBACK_RUNTIME_EXCEPTION_MESSAGE);
+        assertWarnLog(END_RUNTIME_EXCEPTION_MESSAGE);
     }
 
     /**
@@ -587,8 +593,8 @@ public class SimpleDbTransactionExecutorTest {
      * <h2>テスト内容</h2>
      * <ul>
      * <li>SQL実行時にErrorが発生し、ロールバック時にはRuntimeExceptionが発生し、トランザクションの終了時にはErrorが発生する場合</li>
-     * <li>呼び出し元には、ロールバック時に発生した例外が送出されること。</li>
-     * <li>SQL実行時とロールバック時のRuntimeExceptionは、ワーニングレベルでログ出力されること。</li>
+     * <li>呼び出し元には、SQL実行時に発生した例外が送出されること。</li>
+     * <li>ロールバック時とトランザクションの終了時の例外は、ワーニングレベルでログ出力されること。</li>
      * </ul>
      */
     @Test
@@ -601,8 +607,8 @@ public class SimpleDbTransactionExecutorTest {
                             SimpleDbTransactionManagerError.ERROR_STATEMENT.END_ERROR))
                     .doTransaction();
             fail("does not run.");
-        } catch (RuntimeException e) {
-            assertThat(e.getMessage(), is("rollback runtime error."));
+        } catch (Error e) {
+            assertThat(e.getMessage(), is(EXECUTE_ERROR_MESSAGE));
         }
 
 
@@ -611,8 +617,8 @@ public class SimpleDbTransactionExecutorTest {
 
         // ログのアサート
         assertWarnLogCountIs(2);
-        assertWarnLog("java.lang.Error: Error");
-        assertWarnLog("java.lang.Error: end Error");
+        assertWarnLog(ROLLBACK_RUNTIME_EXCEPTION_MESSAGE);
+        assertWarnLog(END_ERROR_MESSAGE);
     }
 
     /**
@@ -622,7 +628,7 @@ public class SimpleDbTransactionExecutorTest {
      * <ul>
      * <li>SQL実行時にRuntimeExceptionが発生し、ロールバックとトランザクションの終了時にはErrorが発生する場合</li>
      * <li>呼び出し元には、ロールバック時に発生した例外が送出されること。</li>
-     * <li>SQL実行時とロールバック時のRuntimeExceptionは、ワーニングレベルでログ出力されること。</li>
+     * <li>SQL実行時とトランザクションの終了時の例外は、ワーニングレベルでログ出力されること。</li>
      * </ul>
      */
     @Test
@@ -636,7 +642,7 @@ public class SimpleDbTransactionExecutorTest {
                     .doTransaction();
             fail("does not run.");
         } catch (Error e) {
-            assertThat(e.getMessage(), is("rollback Error."));
+            assertThat(e.getMessage(), is(ROLLBACK_ERROR_MESSAGE));
         }
 
 
@@ -645,8 +651,8 @@ public class SimpleDbTransactionExecutorTest {
 
         // ログのアサート
         assertWarnLogCountIs(2);
-        assertWarnLog("java.lang.RuntimeException: runtime exception");
-        assertWarnLog("java.lang.Error: end Error");
+        assertWarnLog(EXECUTE_RUNTIME_EXCEPTION_MESSAGE);
+        assertWarnLog(END_ERROR_MESSAGE);
     }
 
     /**
@@ -673,7 +679,7 @@ public class SimpleDbTransactionExecutorTest {
 
         // ログのアサート
         assertWarnLogCountIs(1);
-        assertWarnLog("java.lang.RuntimeException: end runtime error.");
+        assertWarnLog(END_RUNTIME_EXCEPTION_MESSAGE);
     }
 
     /**
@@ -682,24 +688,27 @@ public class SimpleDbTransactionExecutorTest {
      * <h2>テスト内容</h2>
      * <ul>
      * <li>トランザクションの終了時にはErrorが発生する場合</li>
-     * <li>呼び出し元には、例外が送出されないこと。</li>
+     * <li>呼び出し元には、トランザクションの終了時に発生した例外が送出されること。</li>
      * <li>コミットは成功しているので、更新処理が反映されていること。</li>
      * </ul>
      */
     @Test
     public void testDoTransaction_ErrorAtEnd() {
-        new SimpleDbTransactionExecutorSub(
-                new SimpleDbTransactionManagerError(
-                        transaction,
-                        SimpleDbTransactionManagerError.ERROR_STATEMENT.END_ERROR))
-                .doTransaction();
+        try {
+            new SimpleDbTransactionExecutorSub(
+                    new SimpleDbTransactionManagerError(
+                            transaction,
+                            SimpleDbTransactionManagerError.ERROR_STATEMENT.END_ERROR))
+                    .doTransaction();
+        } catch (Error e){
+            assertThat(e.getMessage(), is(END_ERROR_MESSAGE));
+        }
 
         TestEntity entity = VariousDbTestHelper.findById(TestEntity.class, ID);
         assertThat("コミットは成功しているので、更新処理が正しく行われていること", entity.col2, is(UPDATED_VALUE));
 
         // ログのアサート
-        assertWarnLogCountIs(1);
-        assertWarnLog("java.lang.Error: end Error.");
+        assertWarnLogCountIs(0);
     }
 
     /**
@@ -812,9 +821,9 @@ public class SimpleDbTransactionExecutorTest {
         public void rollbackTransaction() {
             transactionManager.rollbackTransaction();
             if (is(errorState, ERROR_STATEMENT.ROLLBACK_RUNTIME)) {
-                throw new RuntimeException("rollback runtime error.");
+                throw new RuntimeException(ROLLBACK_RUNTIME_EXCEPTION_MESSAGE);
             } else if (is(errorState, ERROR_STATEMENT.ROLLBACK_ERROR)) {
-                throw new Error("rollback Error.");
+                throw new Error(ROLLBACK_ERROR_MESSAGE);
             }
         }
 
@@ -822,9 +831,9 @@ public class SimpleDbTransactionExecutorTest {
         public void endTransaction() {
             transactionManager.endTransaction();
             if (is(errorState, ERROR_STATEMENT.END_RUNTIME)) {
-                throw new RuntimeException("end runtime error.");
+                throw new RuntimeException(END_RUNTIME_EXCEPTION_MESSAGE);
             } else if (is(errorState, ERROR_STATEMENT.END_ERROR)) {
-                throw new Error("end Error.");
+                throw new Error(END_ERROR_MESSAGE);
             }
         }
 
@@ -897,7 +906,7 @@ public class SimpleDbTransactionExecutorTest {
         public Integer execute(AppDbConnection connection) {
             super.execute(connection);
             // エラーを発生させる。
-            throw new RuntimeException("runtime exception.");
+            throw new RuntimeException(EXECUTE_RUNTIME_EXCEPTION_MESSAGE);
         }
     }
 
@@ -922,7 +931,7 @@ public class SimpleDbTransactionExecutorTest {
         public Integer execute(AppDbConnection connection) {
             super.execute(connection);
             // エラーを発生させる。
-            throw new Error("Error.");
+            throw new Error(EXECUTE_ERROR_MESSAGE);
         }
     }
 }

--- a/src/test/java/nablarch/core/db/transaction/SimpleDbTransactionExecutorTest.java
+++ b/src/test/java/nablarch/core/db/transaction/SimpleDbTransactionExecutorTest.java
@@ -700,7 +700,7 @@ public class SimpleDbTransactionExecutorTest {
                             transaction,
                             SimpleDbTransactionManagerError.ERROR_STATEMENT.END_ERROR))
                     .doTransaction();
-        } catch (Error e){
+        } catch (Error e) {
             assertThat(e.getMessage(), is(END_ERROR_MESSAGE));
         }
 
@@ -736,7 +736,7 @@ public class SimpleDbTransactionExecutorTest {
      *
      * @param count ログのカウント
      */
-    private static void assertWarnLogCountIs(int count){
+    private static void assertWarnLogCountIs(int count) {
         List<String> log = OnMemoryLogWriter.getMessages("writer.memory");
         int warnCount = 0;
         for (String logMessage : log) {
@@ -758,13 +758,13 @@ public class SimpleDbTransactionExecutorTest {
      *
      */
     @Entity
-    @Table(name="SBT_TEST_TABLE")
+    @Table(name = "SBT_TEST_TABLE")
     public static class TestEntity {
         @Id
-        @Column(name="col1", length=5, nullable = false)
+        @Column(name = "col1", length = 5, nullable = false)
         public String col1;
 
-        @Column(name="col2", length=100)
+        @Column(name = "col2", length = 100)
         public String col2;
 
         private static TestEntity create(String col1, String col2) {


### PR DESCRIPTION
#67 にて`SimpleDbTransactionExecutor`のfinally句で発生した例外はワーニングログを出すのみで伝播させないように修正した。
しかし、Errorは発生した場合、通常アプリケーション続行不可能なためfinally句で握りつぶさず伝播させ適切なハンドラで補足するべきである。
そのため、以下の優先度で例外を送出するよう修正を行った。

1. ロールバック処理で発生したError
2. executeまたはコミットで発生したError
3. DBコネクションの終了処理で発生したError
4. ロールバック処理で発生したRuntimeException
5. executeまたはコミットで発生したRuntimeException

![decision_table](https://github.com/nablarch/nablarch-core-jdbc/assets/58413950/98f63945-6624-4053-b080-70da840afdfc)

`SimpleDbTransactionExecutorTest`のテストメソッドと各処理が送出する例外の対応は以下。
|execute or commit|rollback|endTransaction|test method|
|---|---|---|---|
|RuntimeException|RuntimeException|RuntimeException|testDoTransaction_ExceptionAtExecuteAndRollbackAndEnd|
|RuntimeException|RuntimeException|Error|testDoTransaction_ExceptionAtExecuteAndRollback_ErrorAtEnd|
|RuntimeException|RuntimeException||testDoTransaction_ExceptionAtExecuteAndRollback|
|RuntimeException|Error|RuntimeException|testDoTransaction_ExceptionAtExecute_ErrorAtRollback_ExceptionAtEnd|
|RuntimeException|Error|Error|testDoTransaction_ExceptionAtExecute_ErrorAtRollbackAndEnd|
|RuntimeException|Error||testDoTransaction_ExceptionAtExecute_ErrorAtRollback|
|RuntimeException||RuntimeException|testDoTransaction_ExceptionAtExecuteAndEnd|
|RuntimeException||Error|testDoTransaction_ExceptionAtExecute_ErrorAtEnd|
|RuntimeException|||testDoTransaction_ExceptionAtExecute|
|Error|RuntimeException|RuntimeException|testDoTransaction_ErrorAtExecute_ExceptionAtRollbackAndEnd|
|Error|RuntimeException|Error|testDoTransaction_ErrorAtExecute_ExceptionAtRollback_ErrorAndEnd|
|Error|RuntimeException||testDoTransaction_ErrorAtExecute_ExceptionAtRollback|
|Error|Error|RuntimeException|testDoTransaction_ErrorAtExecuteAndRollback_ExceptionAtEnd|
|Error|Error|Error|testDoTransaction_ErrorAtExecuteAndRollbackAndEnd|
|Error|Error||testDoTransaction_ErrorAtExecuteAndRollback|
|Error||RuntimeException|testDoTransaction_ErrorAtExecute_ExceptionAtEnd|
|Error||Error|testDoTransaction_ErrorAtExecuteAndEnd|
|Error|||testDoTransaction_ErrorAtExecute|
||RuntimeException|RuntimeException|起こり得ない|
||RuntimeException|Error|起こり得ない|
||RuntimeException||起こり得ない|
||Error|RuntimeException|起こり得ない|
||Error|Error|起こり得ない|
||Error||起こり得ない|
|||RuntimeException|testDoTransaction_ExceptionAtEnd|
|||Error|testDoTransaction_ErrorAtEnd|
