### PR TITLE
件数取得用SQLをカスタマイズするための拡張ポイントを追加しました

### DIFF
--- a/src/main/java/nablarch/core/db/connection/BasicDbConnection.java
+++ b/src/main/java/nablarch/core/db/connection/BasicDbConnection.java
@@ -442,8 +442,7 @@ public class BasicDbConnection implements TransactionManagerConnection {
     public ParameterizedSqlPStatement prepareParameterizedCountSqlStatementBySqlId(
             final String sqlId, Object condition) {
 
-        String variableConditionSql = context.getDialect()
-                .convertCountSql(factory.getVariableConditionSqlBySqlId(sqlId, condition));
+        String variableConditionSql = context.getDialect().convertCountSql(sqlId, condition, factory);
         return (ParameterizedSqlPStatement) new BasicDbConnection.StatementCreator() {
             @Override
             SqlStatement createSqlStatement(String sql) throws SQLException {

--- a/src/main/java/nablarch/core/db/connection/BasicDbConnection.java
+++ b/src/main/java/nablarch/core/db/connection/BasicDbConnection.java
@@ -436,7 +436,7 @@ public class BasicDbConnection implements TransactionManagerConnection {
     /**
      * {@inheritDoc}
      *
-     * 件数取得用のSQLへの変換は、{@link Dialect#convertCountSql(String)}で行う。
+     * 件数取得用のSQLへの変換は、{@link Dialect#convertCountSql(String, Object, StatementFactory)}で行う。
      */
     @Override
     public ParameterizedSqlPStatement prepareParameterizedCountSqlStatementBySqlId(
@@ -460,7 +460,7 @@ public class BasicDbConnection implements TransactionManagerConnection {
     /**
      * {@inheritDoc}
      *
-     * 件数取得用のSQLへの変換は、{@link Dialect#convertCountSql(String)}で行う。
+     * 件数取得用のSQLへの変換は、{@link Dialect#convertCountSql(String, Object, StatementFactory)}で行う。
      */
     @Override
     public SqlPStatement prepareCountStatementBySqlId(final String sqlId) {

--- a/src/main/java/nablarch/core/db/connection/BasicDbConnection.java
+++ b/src/main/java/nablarch/core/db/connection/BasicDbConnection.java
@@ -464,8 +464,7 @@ public class BasicDbConnection implements TransactionManagerConnection {
      */
     @Override
     public SqlPStatement prepareCountStatementBySqlId(final String sqlId) {
-        String variableConditionSql = context.getDialect()
-                .convertCountSql(factory.getVariableConditionSqlBySqlId(sqlId, null));
+        String variableConditionSql = context.getDialect().convertCountSql(sqlId, null, factory);
         return (SqlPStatement) new BasicDbConnection.StatementCreator() {
             @Override
             SqlStatement createSqlStatement(String sql) throws SQLException {

--- a/src/main/java/nablarch/core/db/dialect/DefaultDialect.java
+++ b/src/main/java/nablarch/core/db/dialect/DefaultDialect.java
@@ -6,6 +6,7 @@ import java.sql.SQLException;
 
 import nablarch.core.db.statement.ResultSetConvertor;
 import nablarch.core.db.statement.SelectOption;
+import nablarch.core.db.statement.StatementFactory;
 import nablarch.core.util.annotation.Published;
 
 /**
@@ -70,9 +71,9 @@ public class DefaultDialect implements Dialect {
     }
 
     /**
+     * {@inheritDoc}
+     * <p>
      * 全てのカラムを{@link ResultSet#getObject(int)}で取得するコンバータを返す。
-     *
-     * @return {@inheritDoc}
      */
     @Override
     public ResultSetConvertor getResultSetConvertor() {
@@ -110,6 +111,11 @@ public class DefaultDialect implements Dialect {
         return "SELECT COUNT(*) COUNT_ FROM (" + sql + ") SUB_";
     }
 
+    @Override
+    public String convertCountSql(String sqlId, Object params, StatementFactory statementFactory) {
+        return convertCountSql(statementFactory.getVariableConditionSqlBySqlId(sqlId, params));
+    }
+
     /**
      * {@inheritDoc}
      *
@@ -131,7 +137,7 @@ public class DefaultDialect implements Dialect {
         }
 
         @Override
-        public boolean isConvertible(ResultSetMetaData rsmd, int columnIndex) throws SQLException {
+        public boolean isConvertible(ResultSetMetaData rsmd, int columnIndex) {
             return true;
         }
     }

--- a/src/main/java/nablarch/core/db/dialect/DefaultDialect.java
+++ b/src/main/java/nablarch/core/db/dialect/DefaultDialect.java
@@ -112,8 +112,8 @@ public class DefaultDialect implements Dialect {
     }
 
     @Override
-    public String convertCountSql(String sqlId, Object params, StatementFactory statementFactory) {
-        return convertCountSql(statementFactory.getVariableConditionSqlBySqlId(sqlId, params));
+    public String convertCountSql(String sqlId, Object condition, StatementFactory statementFactory) {
+        return convertCountSql(statementFactory.getVariableConditionSqlBySqlId(sqlId, condition));
     }
 
     /**

--- a/src/main/java/nablarch/core/db/dialect/DefaultDialect.java
+++ b/src/main/java/nablarch/core/db/dialect/DefaultDialect.java
@@ -111,6 +111,12 @@ public class DefaultDialect implements Dialect {
         return "SELECT COUNT(*) COUNT_ FROM (" + sql + ") SUB_";
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * デフォルトでは、{@link this#convertCountSql(String)}を使用して、
+     * {@link StatementFactory}から取得したSQLをレコード数取得用SQLに変換する。
+     */
     @Override
     public String convertCountSql(String sqlId, Object condition, StatementFactory statementFactory) {
         return convertCountSql(statementFactory.getVariableConditionSqlBySqlId(sqlId, condition));

--- a/src/main/java/nablarch/core/db/dialect/Dialect.java
+++ b/src/main/java/nablarch/core/db/dialect/Dialect.java
@@ -96,16 +96,14 @@ public interface Dialect {
     String convertCountSql(String sql);
 
     /**
-     * SQLIDから件数取得用のSQL文を取得する。
-     * <p>
-     *
+     * SQLIDからレコード数取得用のSQL文を取得する。
      *
      * @param sqlId SQLID
-     * @param params パラメータ
+     * @param condition 可変条件に設定される条件をもつオブジェクト
      * @param statementFactory ステートメントファクトリ
-     * @return 件数取得用のSQL文
+     * @return レコード数取得用のSQL文
      */
-    String convertCountSql(String sqlId, Object params, StatementFactory statementFactory);
+    String convertCountSql(String sqlId, Object condition, StatementFactory statementFactory);
 
     /**
      * ping用のSQL文を返す。

--- a/src/main/java/nablarch/core/db/dialect/Dialect.java
+++ b/src/main/java/nablarch/core/db/dialect/Dialect.java
@@ -4,6 +4,7 @@ import java.sql.SQLException;
 
 import nablarch.core.db.statement.ResultSetConvertor;
 import nablarch.core.db.statement.SelectOption;
+import nablarch.core.db.statement.StatementFactory;
 import nablarch.core.util.annotation.Published;
 
 /**
@@ -93,6 +94,18 @@ public interface Dialect {
      * @return 変換したSQL文
      */
     String convertCountSql(String sql);
+
+    /**
+     * SQLIDから件数取得用のSQL文を取得する。
+     * <p>
+     *
+     *
+     * @param sqlId SQLID
+     * @param params パラメータ
+     * @param statementFactory ステートメントファクトリ
+     * @return 件数取得用のSQL文
+     */
+    String convertCountSql(String sqlId, Object params, StatementFactory statementFactory);
 
     /**
      * ping用のSQL文を返す。

--- a/src/test/java/nablarch/core/db/dialect/DefaultDialectTest.java
+++ b/src/test/java/nablarch/core/db/dialect/DefaultDialectTest.java
@@ -171,7 +171,7 @@ public class DefaultDialectTest {
         assertThat(actual, is("SELECT COUNT(*) COUNT_ FROM (SELECT USER_NAME, TEL, FROM USER_MTR WHERE (0 = 1 or (USER_NAME = :userName))) SUB_"));
     }
 
-    static class DialectForm {
+    public static class DialectForm {
         public String getUserName() {return "test";}
     }
     /**

--- a/src/test/java/nablarch/core/db/dialect/DefaultDialectTest.java
+++ b/src/test/java/nablarch/core/db/dialect/DefaultDialectTest.java
@@ -164,18 +164,16 @@ public class DefaultDialectTest {
         statementFactory.setSqlParameterParserFactory(new BasicSqlParameterParserFactory());
         statementFactory.setSqlLoader(new BasicSqlLoader());
 
-        TestEntity params = new TestEntity();
-
         // execute
-        String actual = sut.convertCountSql("nablarch.core.db.dialect.DefaultDialectTest#SQL001", params, statementFactory);
+        String actual = sut.convertCountSql("nablarch.core.db.dialect.DefaultDialectTest#SQL001", new DialectForm(), statementFactory);
 
+        // verify
         assertThat(actual, is("SELECT COUNT(*) COUNT_ FROM (SELECT USER_NAME, TEL, FROM USER_MTR WHERE (0 = 1 or (USER_NAME = :userName))) SUB_"));
     }
 
-    public static class TestEntity {
-        public String getUserName() {return "testUser";}
+    static class DialectForm {
+        public String getUserName() {return "test";}
     }
-
     /**
      * ping用のSQL文はサポートしない。
      */

--- a/src/test/java/nablarch/core/db/dialect/H2DialectTest.java
+++ b/src/test/java/nablarch/core/db/dialect/H2DialectTest.java
@@ -315,7 +315,7 @@ public class H2DialectTest {
         final ResultSet rs = statement.executeQuery();
 
         assertThat(rs.next(), is(true));
-        assertThat(rs.getInt(1), is(11));       // name_3とname_3x
+        assertThat(rs.getInt(1), is(11));       // name_3とname_30〜name_39の11件が取得されるはず
     }
 
     /**
@@ -352,7 +352,7 @@ public class H2DialectTest {
         ResultSet rs = statement.executeQuery();
 
         assertThat(rs.next(), is(true));
-        assertThat(rs.getInt(1), is(11));       // name_3とname_3x
+        assertThat(rs.getInt(1), is(11));       // name_3とname_30〜name_39の11件が取得されるはず
     }
 
     /**

--- a/src/test/java/nablarch/core/db/dialect/H2DialectTest.java
+++ b/src/test/java/nablarch/core/db/dialect/H2DialectTest.java
@@ -132,7 +132,6 @@ public class H2DialectTest {
      * {@link H2Dialect#getResultSetConvertor()} のテスト。
      * 取得したConvertorを使って、値の取得ができること。
      */
-    @SuppressWarnings({"JDBCResourceOpenedButNotSafelyClosed", "SqlDialectInspection", "SqlNoDataSourceInspection"})
     @Test
     public void getResultSetConvertor() throws Exception {
         Calendar calendar = Calendar.getInstance();
@@ -144,33 +143,45 @@ public class H2DialectTest {
                 new DialectEntity(1L, "12345", 100, 1234554321L, date, new BigDecimal("12345.54321"), timestamp,
                         new byte[] {0x00, 0x50, (byte) 0xFF}));
         connection = VariousDbTestHelper.getNativeConnection();
-        final PreparedStatement statement = connection.prepareStatement(
-                "SELECT ENTITY_ID, STR, NUM, BIG_INT, DECIMAL_COL, DATE_COL, TIMESTAMP_COL, BINARY_COL FROM DIALECT WHERE ENTITY_ID = ?");
-        statement.setLong(1, 1L);
-        final ResultSet rs = statement.executeQuery();
+        PreparedStatement statement = null;
+        ResultSet rs = null;
+        try {
+            statement = connection.prepareStatement(
+                    "SELECT ENTITY_ID, STR, NUM, BIG_INT, DECIMAL_COL, DATE_COL, TIMESTAMP_COL, BINARY_COL FROM DIALECT WHERE ENTITY_ID = ?");
+            statement.setLong(1, 1L);
+            rs = statement.executeQuery();
 
-        assertThat("1レコードは取得できているはず", rs.next(), is(true));
+            assertThat("1レコードは取得できているはず", rs.next(), is(true));
 
-        final ResultSetConvertor convertor = sut.getResultSetConvertor();
+            final ResultSetConvertor convertor = sut.getResultSetConvertor();
 
-        final ResultSetMetaData meta = rs.getMetaData();
-        final int columnCount = meta.getColumnCount();
+            final ResultSetMetaData meta = rs.getMetaData();
+            final int columnCount = meta.getColumnCount();
 
-        for (int i = 1; i <= columnCount; i++) {
-            assertThat("変換するか否かの結果は全てtrue", convertor.isConvertible(meta, i), is(true));
+            for (int i = 1; i <= columnCount; i++) {
+                assertThat("変換するか否かの結果は全てtrue", convertor.isConvertible(meta, i), is(true));
+            }
+
+            assertThat("文字列はStringで取得できる", (String) convertor.convert(rs, meta, 2), is("12345"));
+            assertThat("数値型はIntegerで取得できる", (Integer) convertor.convert(rs, meta, 3), is(Integer.valueOf("100")));
+            assertThat("10桁以上の数値型はLongで取得できる", (Long) convertor.convert(rs, meta, 4), is(Long.valueOf("1234554321")));
+            assertThat("小数部ありはBigDecimalで取得できる", (BigDecimal) convertor.convert(rs, meta, 5), is(new BigDecimal(
+                    "12345.54321")));
+            assertThat("DATE型はDateで取得できる", (Date) convertor.convert(rs, meta, 6), is(date));
+            assertThat("TIMESTAMP型はTimestampで取得できる", (Timestamp) convertor.convert(rs, meta, 7), is(timestamp));
+
+            // binaryはbyte[]で取得される
+            final byte[] bytes = (byte[]) convertor.convert(rs, meta, 8);
+            assertThat("値が取得出来ていること", bytes, is(new byte[] {0x00, 0x50, (byte) 0xFF}));
+
+        } finally {
+            if (rs != null) {
+                rs.close();
+            }
+            if (statement != null) {
+                statement.close();
+            }
         }
-
-        assertThat("文字列はStringで取得できる", (String) convertor.convert(rs, meta, 2), is("12345"));
-        assertThat("数値型はIntegerで取得できる", (Integer) convertor.convert(rs, meta, 3), is(Integer.valueOf("100")));
-        assertThat("10桁以上の数値型はLongで取得できる", (Long) convertor.convert(rs, meta, 4), is(Long.valueOf("1234554321")));
-        assertThat("小数部ありはBigDecimalで取得できる", (BigDecimal) convertor.convert(rs, meta, 5), is(new BigDecimal(
-                "12345.54321")));
-        assertThat("DATE型はDateで取得できる", (Date) convertor.convert(rs, meta, 6), is(date));
-        assertThat("TIMESTAMP型はTimestampで取得できる", (Timestamp) convertor.convert(rs, meta, 7), is(timestamp));
-
-        // binaryはbyte[]で取得される
-        final byte[] bytes = (byte[]) convertor.convert(rs, meta, 8);
-        assertThat("値が取得出来ていること", bytes, is(new byte[] {0x00, 0x50, (byte) 0xFF}));
     }
 
     /**
@@ -202,7 +213,6 @@ public class H2DialectTest {
      * <p/>
      * offsetのみを指定した場合
      */
-    @SuppressWarnings("JDBCResourceOpenedButNotSafelyClosed")
     @Test
     public void convertPaginationSql_executeOffsetOnly() throws Exception {
         VariousDbTestHelper.delete(DialectEntity.class);
@@ -212,17 +222,28 @@ public class H2DialectTest {
         connection = VariousDbTestHelper.getNativeConnection();
 
         String sql = "select entity_id, str from dialect where str like ? order by entity_id";
-        final PreparedStatement statement = connection.prepareStatement(
-                sut.convertPaginationSql(sql, new SelectOption(50, 0)));
-        statement.setString(1, "name%");
+        PreparedStatement statement = null;
+        ResultSet rs = null;
+        try {
+            statement = connection.prepareStatement(
+                    sut.convertPaginationSql(sql, new SelectOption(50, 0)));
+            statement.setString(1, "name%");
 
-        final ResultSet rs = statement.executeQuery();
-        int index = 49;
-        while (rs.next()) {
-            index++;
-            assertThat(rs.getLong(1), is((long) index));
+            rs = statement.executeQuery();
+            int index = 49;
+            while (rs.next()) {
+                index++;
+                assertThat(rs.getLong(1), is((long) index));
+            }
+            assertThat("最後のレコード番号", index, is(100));
+        } finally {
+            if (rs != null) {
+                rs.close();
+            }
+            if (statement != null) {
+                statement.close();
+            }
         }
-        assertThat("最後のレコード番号", index, is(100));
     }
 
     /**
@@ -230,7 +251,6 @@ public class H2DialectTest {
      * <p/>
      * limitのみを指定した場合
      */
-    @SuppressWarnings("JDBCResourceOpenedButNotSafelyClosed")
     @Test
     public void convertPaginationSql_executeLimitOnly() throws Exception {
         VariousDbTestHelper.delete(DialectEntity.class);
@@ -240,17 +260,28 @@ public class H2DialectTest {
         connection = VariousDbTestHelper.getNativeConnection();
 
         String sql = "select entity_id, str from dialect where str like ? order by entity_id";
-        final PreparedStatement statement = connection.prepareStatement(
-                sut.convertPaginationSql(sql, new SelectOption(0, 25)));
-        statement.setString(1, "name%");
+        PreparedStatement statement = null;
+        ResultSet rs = null;
+        try {
+            statement = connection.prepareStatement(
+                    sut.convertPaginationSql(sql, new SelectOption(0, 25)));
+            statement.setString(1, "name%");
 
-        final ResultSet rs = statement.executeQuery();
-        int index = 0;
-        while (rs.next()) {
-            index++;
-            assertThat(rs.getLong(1), is((long) index));
+            rs = statement.executeQuery();
+            int index = 0;
+            while (rs.next()) {
+                index++;
+                assertThat(rs.getLong(1), is((long) index));
+            }
+            assertThat("取得件数は25であること", index, is(25));
+        } finally {
+            if (rs != null) {
+                rs.close();
+            }
+            if (statement != null) {
+                statement.close();
+            }
         }
-        assertThat("取得件数は25であること", index, is(25));
     }
 
     /**
@@ -258,7 +289,6 @@ public class H2DialectTest {
      * <p/>
      * offsetとlimitの両方を指定
      */
-    @SuppressWarnings("JDBCResourceOpenedButNotSafelyClosed")
     @Test
     public void convertPaginationSql_executeOffsetAndLimit() throws Exception {
         VariousDbTestHelper.delete(DialectEntity.class);
@@ -268,17 +298,28 @@ public class H2DialectTest {
         connection = VariousDbTestHelper.getNativeConnection();
 
         String sql = "select entity_id, str from dialect where str like ? order by entity_id";
-        final PreparedStatement statement = connection.prepareStatement(
-                sut.convertPaginationSql(sql, new SelectOption(31, 15)));
-        statement.setString(1, "name%");
+        PreparedStatement statement = null;
+        ResultSet rs = null;
+        try {
+            statement = connection.prepareStatement(
+                    sut.convertPaginationSql(sql, new SelectOption(31, 15)));
+            statement.setString(1, "name%");
 
-        final ResultSet rs = statement.executeQuery();
-        int index = 30;
-        while (rs.next()) {
-            index++;
-            assertThat(rs.getLong(1), is((long) index));
+            rs = statement.executeQuery();
+            int index = 30;
+            while (rs.next()) {
+                index++;
+                assertThat(rs.getLong(1), is((long) index));
+            }
+            assertThat("最後に取得されたレコードの番号は45であること", index, is(45));
+        } finally {
+            if (rs != null) {
+                rs.close();
+            }
+            if (statement != null) {
+                statement.close();
+            }
         }
-        assertThat("最後に取得されたレコードの番号は45であること", index, is(45));
     }
 
     /**
@@ -301,7 +342,6 @@ public class H2DialectTest {
     /**
      * {@link H2Dialect#convertCountSql(String)}で変換したSQL文が実行可能であることを確認する。
      */
-    @SuppressWarnings("JDBCResourceOpenedButNotSafelyClosed")
     @Test
     public void convertCountSql_execute() throws Exception {
         VariousDbTestHelper.delete(DialectEntity.class);
@@ -310,12 +350,23 @@ public class H2DialectTest {
         }
         connection = VariousDbTestHelper.getNativeConnection();
         String sql = "select entity_id, str from dialect where str like ? order by entity_id";
-        final PreparedStatement statement = connection.prepareStatement(sut.convertCountSql(sql));
-        statement.setString(1, "name_3%");
-        final ResultSet rs = statement.executeQuery();
+        PreparedStatement statement = null;
+        ResultSet rs = null;
+        try {
+            statement = connection.prepareStatement(sut.convertCountSql(sql));
+            statement.setString(1, "name_3%");
+            rs = statement.executeQuery();
 
-        assertThat(rs.next(), is(true));
-        assertThat(rs.getInt(1), is(11));       // name_3とname_30〜name_39の11件が取得されるはず
+            assertThat(rs.next(), is(true));
+            assertThat(rs.getInt(1), is(11));       // name_3とname_30〜name_39の11件が取得されるはず
+        } finally {
+            if (rs != null) {
+                rs.close();
+            }
+            if (statement != null) {
+                statement.close();
+            }
+        }
     }
 
     /**
@@ -334,7 +385,6 @@ public class H2DialectTest {
     /**
      * {@link H2Dialect#convertCountSql(String, Object, StatementFactory)}で変換したSQL文が実行可能であることを確認する。
      */
-    @SuppressWarnings("JDBCResourceOpenedButNotSafelyClosed")
     @Test
     public void convertCountSqlFromSqlId_execute() throws Exception {
         VariousDbTestHelper.delete(DialectEntity.class);
@@ -346,13 +396,24 @@ public class H2DialectTest {
         statementFactory.setSqlParameterParserFactory(new BasicSqlParameterParserFactory());
         statementFactory.setSqlLoader(new BasicSqlLoader());
 
-        PreparedStatement statement =
-                connection.prepareStatement(sut.convertCountSql("nablarch.core.db.dialect.H2DialectTest#SQL002", null, statementFactory));
-        statement.setString(1, "name_3%");
-        ResultSet rs = statement.executeQuery();
+        PreparedStatement statement = null;
+        ResultSet rs = null;
+        try {
+            statement =
+                    connection.prepareStatement(sut.convertCountSql("nablarch.core.db.dialect.H2DialectTest#SQL002", null, statementFactory));
+            statement.setString(1, "name_3%");
+            rs = statement.executeQuery();
 
-        assertThat(rs.next(), is(true));
-        assertThat(rs.getInt(1), is(11));       // name_3とname_30〜name_39の11件が取得されるはず
+            assertThat(rs.next(), is(true));
+            assertThat(rs.getInt(1), is(11));       // name_3とname_30〜name_39の11件が取得されるはず
+        } finally {
+            if (rs != null) {
+                rs.close();
+            }
+            if (statement != null) {
+                statement.close();
+            }
+        }
     }
 
     /**

--- a/src/test/java/nablarch/core/db/dialect/H2DialectTest.java
+++ b/src/test/java/nablarch/core/db/dialect/H2DialectTest.java
@@ -346,10 +346,10 @@ public class H2DialectTest {
         statementFactory.setSqlParameterParserFactory(new BasicSqlParameterParserFactory());
         statementFactory.setSqlLoader(new BasicSqlLoader());
 
-        final PreparedStatement statement =
+        PreparedStatement statement =
                 connection.prepareStatement(sut.convertCountSql("nablarch.core.db.dialect.H2DialectTest#SQL002", null, statementFactory));
         statement.setString(1, "name_3%");
-        final ResultSet rs = statement.executeQuery();
+        ResultSet rs = statement.executeQuery();
 
         assertThat(rs.next(), is(true));
         assertThat(rs.getInt(1), is(11));       // name_3とname_3x

--- a/src/test/java/nablarch/core/db/dialect/OracleDialectTest.java
+++ b/src/test/java/nablarch/core/db/dialect/OracleDialectTest.java
@@ -374,7 +374,7 @@ public class OracleDialectTest {
         final ResultSet rs = statement.executeQuery();
 
         assertThat(rs.next(), is(true));
-        assertThat(rs.getInt(1), is(11));       // name_3とname_3x
+        assertThat(rs.getInt(1), is(11));       // name_3とname_30〜name_39の11件が取得されるはず
     }
 
     /**
@@ -411,7 +411,7 @@ public class OracleDialectTest {
         ResultSet rs = statement.executeQuery();
 
         assertThat(rs.next(), is(true));
-        assertThat(rs.getInt(1), is(11));       // name_3とname_3x
+        assertThat(rs.getInt(1), is(11));       // name_3とname_30〜name_39の11件が取得されるはず
     }
 
     /**

--- a/src/test/java/nablarch/core/db/dialect/OracleDialectTest.java
+++ b/src/test/java/nablarch/core/db/dialect/OracleDialectTest.java
@@ -405,10 +405,10 @@ public class OracleDialectTest {
         statementFactory.setSqlParameterParserFactory(new BasicSqlParameterParserFactory());
         statementFactory.setSqlLoader(new BasicSqlLoader());
 
-        final PreparedStatement statement =
+        PreparedStatement statement =
                 connection.prepareStatement(sut.convertCountSql("nablarch.core.db.dialect.OracleDialectTest#SQL002", null, statementFactory));
         statement.setString(1, "name_3%");
-        final ResultSet rs = statement.executeQuery();
+        ResultSet rs = statement.executeQuery();
 
         assertThat(rs.next(), is(true));
         assertThat(rs.getInt(1), is(11));       // name_3とname_3x

--- a/src/test/java/nablarch/core/db/dialect/PostgreSQLDialectTest.java
+++ b/src/test/java/nablarch/core/db/dialect/PostgreSQLDialectTest.java
@@ -318,7 +318,7 @@ public class PostgreSQLDialectTest {
         final ResultSet rs = statement.executeQuery();
 
         assertThat(rs.next(), is(true));
-        assertThat(rs.getInt(1), is(11));       // name_3とname_3x
+        assertThat(rs.getInt(1), is(11));       // name_3とname_30〜name_39の11件が取得されるはず
     }
 
     /**
@@ -355,7 +355,7 @@ public class PostgreSQLDialectTest {
         ResultSet rs = statement.executeQuery();
 
         assertThat(rs.next(), is(true));
-        assertThat(rs.getInt(1), is(11));       // name_3とname_3x
+        assertThat(rs.getInt(1), is(11));       // name_3とname_30〜name_39の11件が取得されるはず
     }
 
     /**

--- a/src/test/java/nablarch/core/db/dialect/PostgreSQLDialectTest.java
+++ b/src/test/java/nablarch/core/db/dialect/PostgreSQLDialectTest.java
@@ -349,10 +349,10 @@ public class PostgreSQLDialectTest {
         statementFactory.setSqlParameterParserFactory(new BasicSqlParameterParserFactory());
         statementFactory.setSqlLoader(new BasicSqlLoader());
 
-        final PreparedStatement statement =
+        PreparedStatement statement =
                 connection.prepareStatement(sut.convertCountSql("nablarch.core.db.dialect.PostgreSQLDialectTest#SQL002", null, statementFactory));
         statement.setString(1, "name_3%");
-        final ResultSet rs = statement.executeQuery();
+        ResultSet rs = statement.executeQuery();
 
         assertThat(rs.next(), is(true));
         assertThat(rs.getInt(1), is(11));       // name_3とname_3x

--- a/src/test/java/nablarch/core/db/dialect/SqlServerDialectTest.java
+++ b/src/test/java/nablarch/core/db/dialect/SqlServerDialectTest.java
@@ -265,10 +265,10 @@ public class SqlServerDialectTest {
         statementFactory.setSqlParameterParserFactory(new BasicSqlParameterParserFactory());
         statementFactory.setSqlLoader(new BasicSqlLoader());
 
-        final PreparedStatement statement =
+        PreparedStatement statement =
                 connection.prepareStatement(sut.convertCountSql("nablarch.core.db.dialect.SqlServerDialectTest#SQL002", null, statementFactory));
         statement.setString(1, "name_3%");
-        final ResultSet rs = statement.executeQuery();
+        ResultSet rs = statement.executeQuery();
 
         assertThat(rs.next(), is(true));
         assertThat(rs.getInt(1), is(11));       // name_3とname_3x

--- a/src/test/java/nablarch/core/db/dialect/SqlServerDialectTest.java
+++ b/src/test/java/nablarch/core/db/dialect/SqlServerDialectTest.java
@@ -234,7 +234,7 @@ public class SqlServerDialectTest {
         final ResultSet rs = statement.executeQuery();
 
         assertThat(rs.next(), is(true));
-        assertThat(rs.getInt(1), is(11));       // name_3とname_3x
+        assertThat(rs.getInt(1), is(11));       // name_3とname_30〜name_39の11件が取得されるはず
     }
 
     /**
@@ -271,7 +271,7 @@ public class SqlServerDialectTest {
         ResultSet rs = statement.executeQuery();
 
         assertThat(rs.next(), is(true));
-        assertThat(rs.getInt(1), is(11));       // name_3とname_3x
+        assertThat(rs.getInt(1), is(11));       // name_3とname_30〜name_39の11件が取得されるはず
     }
 
     /**

--- a/src/test/java/nablarch/core/db/dialect/SqlServerDialectTest.java
+++ b/src/test/java/nablarch/core/db/dialect/SqlServerDialectTest.java
@@ -131,7 +131,6 @@ public class SqlServerDialectTest {
      * {@link SqlServerDialect#getResultSetConvertor()} のテスト。
      * 取得したConvertorを使って、値の取得ができること。
      */
-    @SuppressWarnings({"JDBCResourceOpenedButNotSafelyClosed", "SqlDialectInspection", "SqlNoDataSourceInspection"})
     @Test
     public void getResultSetConvertor() throws Exception {
         Calendar calendar = Calendar.getInstance();
@@ -144,43 +143,54 @@ public class SqlServerDialectTest {
                         timestamp,
                         new byte[] {0x00, 0x50, (byte) 0xFF}));
         connection = VariousDbTestHelper.getNativeConnection();
-        final PreparedStatement statement = connection.prepareStatement(
-                "SELECT ENTITY_ID, STR, NUM, BIG_INT, DECIMAL_COL, DATE_COL, TIMESTAMP_COL, BINARY_COL, LONG_VAR_BINARY"
-                        + " FROM SQL_SERVER_DIALECT WHERE ENTITY_ID = ?");
-        statement.setLong(1, 1L);
-        final ResultSet rs = statement.executeQuery();
+        PreparedStatement statement = null;
+        ResultSet rs = null;
+        try {
+            statement = connection.prepareStatement(
+                    "SELECT ENTITY_ID, STR, NUM, BIG_INT, DECIMAL_COL, DATE_COL, TIMESTAMP_COL, BINARY_COL, LONG_VAR_BINARY"
+                            + " FROM SQL_SERVER_DIALECT WHERE ENTITY_ID = ?");
+            statement.setLong(1, 1L);
+            rs = statement.executeQuery();
 
-        assertThat("1レコードは取得できているはず", rs.next(), is(true));
+            assertThat("1レコードは取得できているはず", rs.next(), is(true));
 
-        final ResultSetConvertor convertor = sut.getResultSetConvertor();
+            final ResultSetConvertor convertor = sut.getResultSetConvertor();
 
-        final ResultSetMetaData meta = rs.getMetaData();
-        final int columnCount = meta.getColumnCount();
+            final ResultSetMetaData meta = rs.getMetaData();
+            final int columnCount = meta.getColumnCount();
 
-        for (int i = 1; i <= columnCount; i++) {
-            assertThat("変換するか否かの結果は全てtrue", convertor.isConvertible(meta, i), is(true));
+            for (int i = 1; i <= columnCount; i++) {
+                assertThat("変換するか否かの結果は全てtrue", convertor.isConvertible(meta, i), is(true));
+            }
+
+            assertThat("文字列はStringで取得できる", (String) convertor.convert(rs, meta, 2), is("12345"));
+            assertThat("数値型はIntegerで取得できる", (Integer) convertor.convert(rs, meta, 3), is(Integer.valueOf("100")));
+            assertThat("10桁以上の数値型はLongで取得できる", (Long) convertor.convert(rs, meta, 4), is(Long.valueOf("1234554321")));
+            assertThat("小数部ありはBigDecimalで取得できる", (BigDecimal) convertor.convert(rs, meta, 5), is(new BigDecimal(
+                    "12345.54321")));
+            assertThat("DATE型はjava.sql.Dateで取得できる", (java.sql.Date) convertor.convert(rs, meta, 6), is(new java.sql.Date(date.getTime())));
+            assertThat("TIMESTAMP型はTimestampで取得できる", (Timestamp) convertor.convert(rs, meta, 7), is(timestamp));
+
+            // binaryはbyte[]で取得される
+            final byte[] bytes = (byte[]) convertor.convert(rs, meta, 8);
+            assertThat("値が取得出来ていること", bytes, is(new byte[] {0x00, 0x50, (byte) 0xFF}));
+
+            // long_var_binaryはBinaryInputStreamで取得できること
+            final InputStream stream = (InputStream) convertor.convert(rs, meta, 9);
+
+            byte[] b = new byte[1024];
+            final int readed = stream.read(b);
+            assertThat("3バイトリードできる", readed, is(3));
+
+            assertThat(Arrays.copyOf(b, 3), is(new byte[] {0x00, 0x50, (byte) 0xFF}));
+        } finally {
+            if(rs != null) {
+                rs.close();
+            }
+            if(statement != null) {
+                statement.close();
+            }
         }
-
-        assertThat("文字列はStringで取得できる", (String) convertor.convert(rs, meta, 2), is("12345"));
-        assertThat("数値型はIntegerで取得できる", (Integer) convertor.convert(rs, meta, 3), is(Integer.valueOf("100")));
-        assertThat("10桁以上の数値型はLongで取得できる", (Long) convertor.convert(rs, meta, 4), is(Long.valueOf("1234554321")));
-        assertThat("小数部ありはBigDecimalで取得できる", (BigDecimal) convertor.convert(rs, meta, 5), is(new BigDecimal(
-                "12345.54321")));
-        assertThat("DATE型はjava.sql.Dateで取得できる", (java.sql.Date) convertor.convert(rs, meta, 6), is(new java.sql.Date(date.getTime())));
-        assertThat("TIMESTAMP型はTimestampで取得できる", (Timestamp) convertor.convert(rs, meta, 7), is(timestamp));
-
-        // binaryはbyte[]で取得される
-        final byte[] bytes = (byte[]) convertor.convert(rs, meta, 8);
-        assertThat("値が取得出来ていること", bytes, is(new byte[] {0x00, 0x50, (byte) 0xFF}));
-
-        // long_var_binaryはBinaryInputStreamで取得できること
-        final InputStream stream = (InputStream) convertor.convert(rs, meta, 9);
-
-        byte[] b = new byte[1024];
-        final int readed = stream.read(b);
-        assertThat("3バイトリードできる", readed, is(3));
-
-        assertThat(Arrays.copyOf(b, 3), is(new byte[] {0x00, 0x50, (byte) 0xFF}));
 
     }
 
@@ -220,7 +230,6 @@ public class SqlServerDialectTest {
     /**
      * {@link SqlServerDialect#convertCountSql(String)}で変換したSQL文が実行可能であることを確認する。
      */
-    @SuppressWarnings("JDBCResourceOpenedButNotSafelyClosed")
     @Test
     public void convertCountSql_execute() throws Exception {
         VariousDbTestHelper.delete(SqlServerDialectEntity.class);
@@ -229,12 +238,23 @@ public class SqlServerDialectTest {
         }
         connection = VariousDbTestHelper.getNativeConnection();
         String sql = "select entity_id, str from sql_server_dialect where str like ? order by entity_id";
-        final PreparedStatement statement = connection.prepareStatement(sut.convertCountSql(sql));
-        statement.setString(1, "name_3%");
-        final ResultSet rs = statement.executeQuery();
+        PreparedStatement statement = null;
+        ResultSet rs = null;
+        try {
+            statement = connection.prepareStatement(sut.convertCountSql(sql));
+            statement.setString(1, "name_3%");
+            rs = statement.executeQuery();
 
-        assertThat(rs.next(), is(true));
-        assertThat(rs.getInt(1), is(11));       // name_3とname_30〜name_39の11件が取得されるはず
+            assertThat(rs.next(), is(true));
+            assertThat(rs.getInt(1), is(11));       // name_3とname_30〜name_39の11件が取得されるはず
+        } finally {
+            if(rs != null) {
+                rs.close();
+            }
+            if(statement != null) {
+                statement.close();
+            }
+        }
     }
 
     /**
@@ -253,7 +273,6 @@ public class SqlServerDialectTest {
     /**
      * {@link SqlServerDialect#convertCountSql(String, Object, StatementFactory)}で変換したSQL文が実行可能であることを確認する。
      */
-    @SuppressWarnings("JDBCResourceOpenedButNotSafelyClosed")
     @Test
     public void convertCountSqlFromSqlId_execute() throws Exception {
         VariousDbTestHelper.delete(DialectEntity.class);
@@ -265,13 +284,24 @@ public class SqlServerDialectTest {
         statementFactory.setSqlParameterParserFactory(new BasicSqlParameterParserFactory());
         statementFactory.setSqlLoader(new BasicSqlLoader());
 
-        PreparedStatement statement =
-                connection.prepareStatement(sut.convertCountSql("nablarch.core.db.dialect.SqlServerDialectTest#SQL002", null, statementFactory));
-        statement.setString(1, "name_3%");
-        ResultSet rs = statement.executeQuery();
+        PreparedStatement statement = null;
+        ResultSet rs = null;
+        try {
+            statement =
+                    connection.prepareStatement(sut.convertCountSql("nablarch.core.db.dialect.SqlServerDialectTest#SQL002", null, statementFactory));
+            statement.setString(1, "name_3%");
+            rs = statement.executeQuery();
 
-        assertThat(rs.next(), is(true));
-        assertThat(rs.getInt(1), is(11));       // name_3とname_30〜name_39の11件が取得されるはず
+            assertThat(rs.next(), is(true));
+            assertThat(rs.getInt(1), is(11));       // name_3とname_30〜name_39の11件が取得されるはず
+        } finally {
+            if (rs != null) {
+                rs.close();
+            }
+            if (statement != null) {
+                statement.close();
+            }
+        }
     }
 
     /**

--- a/src/test/resources/nablarch/core/db/dialect/DefaultDialectTest.sql
+++ b/src/test/resources/nablarch/core/db/dialect/DefaultDialectTest.sql
@@ -1,0 +1,6 @@
+-- SQLID:SQL001
+SQL001 =
+SELECT USER_NAME,
+        TEL,
+  FROM USER_MTR
+  WHERE $if(userName) {USER_NAME = :userName}

--- a/src/test/resources/nablarch/core/db/dialect/H2DialectTest.sql
+++ b/src/test/resources/nablarch/core/db/dialect/H2DialectTest.sql
@@ -1,0 +1,7 @@
+-- SQLID:SQL001
+SQL001 =
+select * from hog_table order by id, name
+
+-- SQLID:SQL002
+SQL002 =
+select entity_id, str from dialect where str like ? order by entity_id

--- a/src/test/resources/nablarch/core/db/dialect/OracleDialectTest.sql
+++ b/src/test/resources/nablarch/core/db/dialect/OracleDialectTest.sql
@@ -1,0 +1,7 @@
+-- SQLID:SQL001
+SQL001 =
+select * from hog_table order by id, name
+
+-- SQLID:SQL002
+SQL002 =
+select entity_id, str from dialect where str like ? order by entity_id

--- a/src/test/resources/nablarch/core/db/dialect/PostgreSQLDialectTest.sql
+++ b/src/test/resources/nablarch/core/db/dialect/PostgreSQLDialectTest.sql
@@ -1,0 +1,7 @@
+-- SQLID:SQL001
+SQL001 =
+select * from hog_table order by id, name
+
+-- SQLID:SQL002
+SQL002 =
+select entity_id, str from dialect where str like ? order by entity_id

--- a/src/test/resources/nablarch/core/db/dialect/SqlServerDialectTest.sql
+++ b/src/test/resources/nablarch/core/db/dialect/SqlServerDialectTest.sql
@@ -1,0 +1,7 @@
+-- SQLID:SQL001
+SQL001 =
+select * from hog_table order by id, name
+
+-- SQLID:SQL002
+SQL002 =
+select entity_id, str from sql_server_dialect where str like ? order by entity_id


### PR DESCRIPTION
- SQLIDから件数取得用SQLを取得するためのメソッド（`convertCountSql(String, Object, StatementFactory)`）を追加しました。
  -  `convertCountSql(String)` を使用している箇所をnablarch organization全体で検索し、上記メソッドで置き換えました。
  - テストを追加しました。
    - DB毎のテストは、CI環境で確認する想定です（H2Dialectのテストのみ、ローカルで実行済みです）
- 今回修正したクラスについて、インスペクションの警告に対応しました。