### PR TITLE
CIのテスト失敗に対応しました

### DIFF
--- a/src/test/java/nablarch/core/db/dialect/SqlServerDialectTest.java
+++ b/src/test/java/nablarch/core/db/dialect/SqlServerDialectTest.java
@@ -267,7 +267,7 @@ public class SqlServerDialectTest {
         statementFactory.setSqlLoader(new BasicSqlLoader());
 
         String actual = sut.convertCountSql("nablarch.core.db.dialect.SqlServerDialectTest#SQL001", null, statementFactory);
-        assertThat(actual, is("SELECT COUNT(*) COUNT_ FROM (select * from hog_table) SUB_"));
+        assertThat(actual, is("SELECT COUNT(*) COUNT_ FROM (select * from hog_table ) SUB_"));
     }
 
     /**


### PR DESCRIPTION
#70 で追加した`SQLServerDialect`のテストがCIで失敗していたことへの対応。

失敗の原因は、期待する結果が誤っていたことによるもの（ `convertCountSql()`での期待結果と同じSQLが期待されるが、違うSQLを記載していた）。