### PR TITLE
CIでのテスト失敗に対応しました

### DIFF
--- a/src/test/java/nablarch/core/db/dialect/SqlServerDialectTest.java
+++ b/src/test/java/nablarch/core/db/dialect/SqlServerDialectTest.java
@@ -23,7 +23,12 @@ import javax.persistence.Table;
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
 
-import nablarch.core.db.statement.*;
+import nablarch.core.db.statement.BasicSqlLoader;
+import nablarch.core.db.statement.BasicSqlParameterParserFactory;
+import nablarch.core.db.statement.BasicStatementFactory;
+import nablarch.core.db.statement.ResultSetConvertor;
+import nablarch.core.db.statement.SelectOption;
+import nablarch.core.db.statement.StatementFactory;
 import nablarch.test.support.db.helper.DatabaseTestRunner;
 import nablarch.test.support.db.helper.DbTestRule;
 import nablarch.test.support.db.helper.TargetDb;

--- a/src/test/java/nablarch/core/db/dialect/SqlServerDialectTest.java
+++ b/src/test/java/nablarch/core/db/dialect/SqlServerDialectTest.java
@@ -275,9 +275,9 @@ public class SqlServerDialectTest {
      */
     @Test
     public void convertCountSqlFromSqlId_execute() throws Exception {
-        VariousDbTestHelper.delete(DialectEntity.class);
+        VariousDbTestHelper.delete(SqlServerDialectEntity.class);
         for (int i = 0; i < 100; i++) {
-            VariousDbTestHelper.insert(new DialectEntity((long) i + 1, "name_" + i));
+            VariousDbTestHelper.insert(new SqlServerDialectEntity((long) i + 1, "name_" + i));
         }
         connection = VariousDbTestHelper.getNativeConnection();
         BasicStatementFactory statementFactory = new BasicStatementFactory();


### PR DESCRIPTION
#70 で追加した`SQLServerDialect`のテストがCIで失敗していたことへの対応。

失敗の原因は、テストで使用するエンティティクラスの不整合によるもの（`SqlServerDialectEntity` を使用すべきところ、`DialectEntity`を使用していた）。

合わせて、`'*' import` を展開した。