### PR TITLE
IgnorePropertyの日本語がJavadocに正しく出力されないため説明追記

### DIFF
--- a/src/main/java/nablarch/core/db/statement/BasicStatementFactory.java
+++ b/src/main/java/nablarch/core/db/statement/BasicStatementFactory.java
@@ -447,6 +447,8 @@ public class BasicStatementFactory implements StatementFactory {
     /**
      * フィールド情報保持インスタンスを設定する。
      *
+     * <p><b>フィールドではなくプロパティアクセスするよう仕様変更を行ったため本プロパティは廃止しました。(値を設定しても意味がありません)</b>
+     *
      * @param objectFieldCache オブジェクトのフィールド情報保持インスタンス
      */
     @IgnoreProperty("フィールドではなくプロパティアクセスするよう仕様変更を行ったため本プロパティは廃止しました。(値を設定しても意味がありません)")

--- a/src/main/java/nablarch/core/db/statement/autoproperty/FieldAnnotationHandlerSupport.java
+++ b/src/main/java/nablarch/core/db/statement/autoproperty/FieldAnnotationHandlerSupport.java
@@ -23,6 +23,8 @@ public abstract class FieldAnnotationHandlerSupport implements AutoPropertyHandl
     /**
      * フィールドアノテーション保持クラスを設定する。
      *
+     * <p><b>フィールドではなくプロパティアクセスするよう仕様変更を行ったため本プロパティは廃止しました。(値を設定しても意味がありません)</b>
+     *
      * @param fieldAnnotationCache フィールドアノテーション保持クラス
      */
     @IgnoreProperty("フィールドではなくプロパティアクセスするよう仕様変更を行ったため本プロパティは廃止しました。(値を設定しても意味がありません)")


### PR DESCRIPTION
## 背景

`@IgnoreProperty`に指定した日本語メッセージがJavadocに正しく出力されない。

## 対応

利用者が読めるように、同じメッセージをJavadocの説明に追記する。