### PR TITLE
公開APIを追加

### DIFF
--- a/src/main/java/nablarch/core/db/dialect/H2Dialect.java
+++ b/src/main/java/nablarch/core/db/dialect/H2Dialect.java
@@ -7,7 +7,7 @@ import nablarch.core.util.annotation.Published;
 
 /**
  * H2用のSQL方言クラス。
- * 
+ * <p>
  * このクラスは、1.4.191 および 2.1.214 により動作確認を行っている。
  * 
  * @author Masaya Seko

--- a/src/main/java/nablarch/core/db/dialect/H2Dialect.java
+++ b/src/main/java/nablarch/core/db/dialect/H2Dialect.java
@@ -3,6 +3,7 @@ package nablarch.core.db.dialect;
 import java.sql.SQLException;
 
 import nablarch.core.db.statement.SelectOption;
+import nablarch.core.util.annotation.Published;
 
 /**
  * H2用のSQL方言クラス。
@@ -12,6 +13,7 @@ import nablarch.core.db.statement.SelectOption;
  * @author Masaya Seko
  *
  */
+@Published(tag = "architect")
 public class H2Dialect extends DefaultDialect {
 
     /** 一意制約違反を表すSQLState */

--- a/src/main/java/nablarch/core/db/statement/SqlCStatement.java
+++ b/src/main/java/nablarch/core/db/statement/SqlCStatement.java
@@ -1,5 +1,7 @@
 package nablarch.core.db.statement;
 
+import nablarch.core.util.annotation.Published;
+
 import java.math.BigDecimal;
 import java.sql.Blob;
 import java.sql.Clob;
@@ -13,6 +15,7 @@ import java.util.Date;
  * @author hisaaki sioiri
  * @see java.sql.CallableStatement
  */
+@Published
 public interface SqlCStatement extends SqlPStatement {
 
     /**


### PR DESCRIPTION
## `H2Dialect`の公開API化
[解説書](https://nablarch.github.io/docs/LATEST/doc/application_framework/application_framework/libraries/database/universal_dao.html#sql)には件数取得SQLのカスタマイズ時にDB毎のダイアレクトを継承するよう案内されているにもかかわらず、公開APIとなっていなかったため、アーキテクト向けの公開APIとしました。

## `SqlCStatement`の公開API化
[解説書](https://nablarch.github.io/docs/LATEST/doc/application_framework/application_framework/libraries/database/database.html#id10)でストアードプロシージャを使用するためのインタフェースとして`SqlCStatement`が案内されているにも関わらず、公開APIとなっていなかったため、プログラマ向けの公開APIとしました。