### PR TITLE
JSR310アダプタの依存関係を削除

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,11 +74,5 @@
       <artifactId>h2</artifactId>
       <scope>test</scope>
     </dependency>
-
-    <dependency>
-      <groupId>com.nablarch.integration</groupId>
-      <artifactId>nablarch-jsr310-adaptor</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 </project>

--- a/src/test/java/nablarch/core/db/statement/BasicSqlPStatementWithJsr310Test.java
+++ b/src/test/java/nablarch/core/db/statement/BasicSqlPStatementWithJsr310Test.java
@@ -33,7 +33,7 @@ public class BasicSqlPStatementWithJsr310Test extends BasicSqlPStatementTestLogi
 
     @Rule
     public SystemRepositoryResource repositoryResource = new SystemRepositoryResource(
-            "nablarch/core/db/statement/BasicSqlPStatementWithJsr310TestConfiguration.xml");
+            "nablarch/core/db/statement/BasicSqlPStatementTestConfiguration.xml");
 
     @Override
     protected ConnectionFactory createConnectionFactory() {

--- a/src/test/resources/nablarch/core/db/statement/BasicSqlPStatementWithJsr310TestConfiguration.xml
+++ b/src/test/resources/nablarch/core/db/statement/BasicSqlPStatementWithJsr310TestConfiguration.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<component-configuration xmlns="http://tis.co.jp/nablarch/component-configuration"
-                         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                         xsi:schemaLocation="http://tis.co.jp/nablarch/component-configuration ../../../../../../main/resources/component-configuration.xsd">
-
-    <import file="db-default.xml" />
-    <import file="JSR310.xml" />
-</component-configuration>


### PR DESCRIPTION
 JSR310が標準機能となったことに伴い、以下の対応を実施

- pom.xmlからJSR310アダプタの依存関係を削除
- BasicSqlPStatementWithJsr310TestConfiguration.xmlを削除
  - 個別のテスト設定が不要になったため
- BasicSqlPStatementWithJsr310Test.javaで読み込むSystemRepositoryResourceを変更
  - 個別のテスト設定が不要になり、共通の設定ファイルを利用できるようになったため
